### PR TITLE
Multipart artifact versions should be Alpha1, not Alpha2

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.netty.contrib</groupId>
         <artifactId>netty-codec-multipart-parent</artifactId>
-        <version>5.0.0.Alpha2-SNAPSHOT</version>
+        <version>5.0.0.Alpha1-SNAPSHOT</version>
     </parent>
 
     <artifactId>netty-codec-multipart-benchmarks</artifactId>

--- a/codec-multipart/pom.xml
+++ b/codec-multipart/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.netty.contrib</groupId>
         <artifactId>netty-codec-multipart-parent</artifactId>
-        <version>5.0.0.Alpha2-SNAPSHOT</version>
+        <version>5.0.0.Alpha1-SNAPSHOT</version>
     </parent>
 
     <artifactId>netty-codec-multipart</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.netty.contrib</groupId>
         <artifactId>netty-codec-multipart-parent</artifactId>
-        <version>5.0.0.Alpha2-SNAPSHOT</version>
+        <version>5.0.0.Alpha1-SNAPSHOT</version>
     </parent>
 
     <artifactId>netty-codec-multipart-examples</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>io.netty.contrib</groupId>
   <artifactId>netty-codec-multipart-parent</artifactId>
-  <version>5.0.0.Alpha2-SNAPSHOT</version>
+  <version>5.0.0.Alpha1-SNAPSHOT</version>
   <name>Netty/Codec/Multipart Parent</name>
   <packaging>pom</packaging>
   <url>https://netty.io/</url>


### PR DESCRIPTION
The artifacts are not yet released, so the initial version for all artifacts should be 5.0.0.**Alpha1**-SNAPSHOT instead of 5.0.0.**Alpha2**-SNAPSHOT
