### PR TITLE
Raw use of parameterized class HttpContent

### DIFF
--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -208,7 +208,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
             if (request instanceof HttpContent) {
                 // Offer automatically if the given request is als type of HttpContent
                 // See #1089
-                offer((HttpContent) request);
+                offer((HttpContent<?>) request);
             } else {
                 parseBody();
             }
@@ -331,7 +331,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
      *             errors
      */
     @Override
-    public HttpPostMultipartRequestDecoder offer(HttpContent content) {
+    public HttpPostMultipartRequestDecoder offer(HttpContent<?> content) {
         checkDestroyed();
 
         if (content instanceof LastHttpContent) {

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestDecoder.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestDecoder.java
@@ -219,7 +219,7 @@ public class HttpPostRequestDecoder implements InterfaceHttpPostRequestDecoder {
     }
 
     @Override
-    public InterfaceHttpPostRequestDecoder offer(HttpContent content) {
+    public InterfaceHttpPostRequestDecoder offer(HttpContent<?> content) {
         return decoder.offer(content);
     }
 

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -67,7 +67,7 @@ import static java.util.AbstractMap.SimpleImmutableEntry;
  * <P>On the contrary, for TRACE method, RFC says:</P>
  * <P>"A client MUST NOT send a message body in a TRACE request."</P>
  */
-public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
+public class HttpPostRequestEncoder implements ChunkedInput<HttpContent<?>> {
 
     /**
      * Different modes to use to encode form data.
@@ -805,7 +805,7 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
             return new WrappedHttpRequest(request);
         } else {
             // get the only one body and set it to the request
-            HttpContent chunk = nextChunk();
+            HttpContent<?> chunk = nextChunk();
             if (request instanceof FullHttpRequest) {
                 FullHttpRequest fullRequest = (FullHttpRequest) request;
                 Buffer chunkContent = chunk.payload();
@@ -894,7 +894,7 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
      * @throws ErrorDataEncoderException
      *             if the encoding is in error
      */
-    private HttpContent encodeNextChunkMultipart(int sizeleft) throws ErrorDataEncoderException {
+    private HttpContent<?> encodeNextChunkMultipart(int sizeleft) throws ErrorDataEncoderException {
         if (currentData == null) {
             return null;
         }
@@ -937,7 +937,7 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
      * @throws ErrorDataEncoderException
      *             if the encoding is in error
      */
-    private HttpContent encodeNextChunkUrlEncoded(int sizeleft) throws ErrorDataEncoderException {
+    private HttpContent<?> encodeNextChunkUrlEncoded(int sizeleft) throws ErrorDataEncoderException {
         if (currentData == null) {
             return null;
         }
@@ -1039,11 +1039,11 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
      *             if the encoding is in error
      */
     @Override
-    public HttpContent readChunk(BufferAllocator allocator) throws Exception {
+    public HttpContent<?> readChunk(BufferAllocator allocator) throws Exception {
         if (isLastChunkSent) {
             return null;
         } else {
-            HttpContent nextChunk = nextChunk();
+            HttpContent<?> nextChunk = nextChunk();
             globalProgress += nextChunk.payload().readableBytes();
             return nextChunk;
         }
@@ -1057,7 +1057,7 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
      * @throws ErrorDataEncoderException
      *             if the encoding is in error
      */
-    private HttpContent nextChunk() throws ErrorDataEncoderException {
+    private HttpContent<?> nextChunk() throws ErrorDataEncoderException {
         if (isLastChunk) {
             isLastChunkSent = true;
             return new EmptyLastHttpContent(DefaultBufferAllocators.onHeapAllocator());
@@ -1072,7 +1072,7 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
         // size > 0
         if (currentData != null) {
             // continue to read data
-            HttpContent chunk;
+            HttpContent<?> chunk;
             if (isMultipart) {
                 chunk = encodeNextChunkMultipart(size);
             } else {
@@ -1089,7 +1089,7 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
         }
         while (size > 0 && iterator.hasNext()) {
             currentData = iterator.next();
-            HttpContent chunk;
+            HttpContent<?> chunk;
             if (isMultipart) {
                 chunk = encodeNextChunkMultipart(size);
             } else {
@@ -1115,7 +1115,7 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
         return size;
     }
 
-    private HttpContent lastChunk() {
+    private HttpContent<?> lastChunk() {
         isLastChunk = true;
         if (currentBuffer == null) {
             isLastChunkSent = true;
@@ -1226,9 +1226,9 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
     }
 
     private static final class WrappedFullHttpRequest extends WrappedHttpRequest implements FullHttpRequest {
-        private final HttpContent content;
+        private final HttpContent<?> content;
 
-        private WrappedFullHttpRequest(HttpRequest request, HttpContent content) {
+        private WrappedFullHttpRequest(HttpRequest request, HttpContent<?> content) {
             super(request);
             this.content = content;
         }
@@ -1259,7 +1259,7 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
         @Override
         public HttpHeaders trailingHeaders() {
             if (content instanceof LastHttpContent) {
-                return ((LastHttpContent) content).trailingHeaders();
+                return ((LastHttpContent<?>) content).trailingHeaders();
             } else {
                 return EmptyHttpHeaders.INSTANCE;
             }

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -156,7 +156,7 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
             if (request instanceof HttpContent) {
                 // Offer automatically if the given request is as type of HttpContent
                 // See #1089
-                offer((HttpContent) request);
+                offer((HttpContent<?>) request);
             } else {
                 parseBody();
             }
@@ -279,7 +279,7 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
      *             errors
      */
     @Override
-    public HttpPostStandardRequestDecoder offer(HttpContent content) {
+    public HttpPostStandardRequestDecoder offer(HttpContent<?> content) {
         checkDestroyed();
 
         if (content instanceof LastHttpContent) {

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/InterfaceHttpPostRequestDecoder.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/InterfaceHttpPostRequestDecoder.java
@@ -92,7 +92,7 @@ public interface InterfaceHttpPostRequestDecoder {
      *             if there is a problem with the charset decoding or other
      *             errors
      */
-    InterfaceHttpPostRequestDecoder offer(HttpContent content);
+    InterfaceHttpPostRequestDecoder offer(HttpContent<?> content);
 
     /**
      * True if at current getStatus, there is an available decoded

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/MemoryAttribute.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/MemoryAttribute.java
@@ -152,9 +152,9 @@ public class MemoryAttribute extends AbstractMemoryHttpData implements Attribute
 
     @Override
     protected Owned<AbstractHttpData> prepareSend() {
-        Send send = getBuffer().send();
+        Send<Buffer> send = getBuffer().send();
         return drop -> {
-            Buffer received = (Buffer) send.receive();
+            Buffer received = send.receive();
             MemoryAttribute attr = new MemoryAttribute(getName());
             attr.setCharset(getCharset());
             attr.setContentInternal(received, received.readableBytes());

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/MemoryFileUpload.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/MemoryFileUpload.java
@@ -141,10 +141,10 @@ public class MemoryFileUpload extends AbstractMemoryHttpData implements FileUplo
 
     @Override
     protected Owned<AbstractHttpData> prepareSend() {
-        Send send = getBuffer().send();
+        Send<Buffer> send = getBuffer().send();
 
         return drop -> {
-            Buffer received = (Buffer) send.receive();
+            Buffer received = send.receive();
             MemoryFileUpload upload = new MemoryFileUpload(
                     getName(), getFilename(), getContentType(), getContentTransferEncoding(), getCharset(), size);
             upload.setContentInternal(received, received.readableBytes());

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/MixedAttribute.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/MixedAttribute.java
@@ -15,7 +15,6 @@
  */
 package io.netty.contrib.handler.codec.http.multipart;
 
-import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.Owned;
 import io.netty5.handler.codec.http.HttpConstants;
 import io.netty5.util.Send;

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestEncoderTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestEncoderTest.java
@@ -338,7 +338,7 @@ public class HttpPostRequestEncoderTest {
         encoder.addBodyFileUpload("myfile", file1, "application/x-zip-compressed", false);
         encoder.finalizeRequest();
         while (! encoder.isEndOfInput()) {
-            HttpContent httpContent = encoder.readChunk((BufferAllocator) null);
+            HttpContent<?> httpContent = encoder.readChunk((BufferAllocator) null);
             Buffer content = httpContent.payload();
             // TODO how to test this ?
 //            assertTrue((content.unwrap() == content || content.unwrap() == null)  ||
@@ -396,7 +396,7 @@ public class HttpPostRequestEncoderTest {
         checkNextChunkSize(encoder, 8080);
         checkNextChunkSize(encoder, 8080);
 
-        HttpContent httpContent = encoder.readChunk((BufferAllocator) null);
+        HttpContent<?> httpContent = encoder.readChunk((BufferAllocator) null);
         assertTrue(httpContent instanceof LastHttpContent, "Expected LastHttpContent is not received");
         httpContent.close();
 
@@ -418,7 +418,7 @@ public class HttpPostRequestEncoderTest {
 
         checkNextChunkSize(encoder, 8080);
 
-        HttpContent httpContent = encoder.readChunk((BufferAllocator) null);
+        HttpContent<?> httpContent = encoder.readChunk((BufferAllocator) null);
         assertTrue(httpContent instanceof LastHttpContent, "Expected LastHttpContent is not received");
         httpContent.close();
 
@@ -433,7 +433,7 @@ public class HttpPostRequestEncoderTest {
         int expectedSizeMin = sizeWithoutDelimiter + 2;
         int expectedSizeMax = sizeWithoutDelimiter + 16;
 
-        HttpContent httpContent = encoder.readChunk((BufferAllocator) null);
+        HttpContent<?> httpContent = encoder.readChunk((BufferAllocator) null);
 
         int readable = httpContent.payload().readableBytes();
         boolean expectedSize = readable >= expectedSizeMin && readable <= expectedSizeMax;

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/http/multipart/HttpUploadClientHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/http/multipart/HttpUploadClientHandler.java
@@ -55,7 +55,7 @@ public class HttpUploadClientHandler extends SimpleChannelInboundHandler<HttpObj
             }
         }
         if (msg instanceof HttpContent) {
-            HttpContent chunk = (HttpContent) msg;
+            HttpContent<?> chunk = (HttpContent<?>) msg;
             System.err.println(chunk.payload().toString(StandardCharsets.UTF_8));
 
             if (chunk instanceof LastHttpContent) {

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/http/multipart/HttpUploadServerHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/http/multipart/HttpUploadServerHandler.java
@@ -169,7 +169,7 @@ public class HttpUploadServerHandler extends SimpleChannelInboundHandler<HttpObj
         if (decoder != null) {
             if (msg instanceof HttpContent) {
                 // New chunk is received
-                HttpContent chunk = (HttpContent) msg;
+                HttpContent<?> chunk = (HttpContent<?>) msg;
                 try {
                     decoder.offer(chunk);
                 } catch (HttpPostRequestDecoder.ErrorDataDecoderException e1) {


### PR DESCRIPTION
# Motivation

The HttpContent class is used without specifying a type parameter or "?" wildcard. For example, HttpPostRequestEncoder class is using HttpContent without a wildcard:

```
public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
```

So, if a user class extends HttpPostRequestEncoder, then he will have to implement the readChunk like this, and he will then get some _Raw use of parameterized class 'HttpContent_" compilation warnings:
```
public void HttpContent readChunk(BufferAllocator allocator) throws Exception;
```

# Modifications

Use HttpContent with a wildcard when it's possible.

# Result

get rid of compilation warnings.