### PR TITLE
Adapt to netty changes for Statics and CharsetUtil

### DIFF
--- a/benchmarks/src/main/java/io/netty/contrib/microbenchmarks/http/multipart/HttpPostMultipartRequestDecoderBenchmark.java
+++ b/benchmarks/src/main/java/io/netty/contrib/microbenchmarks/http/multipart/HttpPostMultipartRequestDecoderBenchmark.java
@@ -27,7 +27,7 @@ import io.netty5.handler.codec.http.HttpHeaderNames;
 import io.netty5.handler.codec.http.HttpMethod;
 import io.netty5.handler.codec.http.HttpVersion;
 import io.netty5.microbench.util.AbstractMicrobenchmark;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
@@ -75,12 +75,12 @@ public class HttpPostMultipartRequestDecoderBenchmark
                     "Content-Disposition: form-data; name=\"msg_id\"\n\n15200\n--" +
                     BOUNDARY +
                     "\nContent-Disposition: form-data; name=\"msg1\"; filename=\"file1.txt\"\n\n" +
-                    data).getBytes(CharsetUtil.UTF_8);
-            byte[] bodyPartBigBytes = data.getBytes(CharsetUtil.UTF_8);
+                    data).getBytes(StandardCharsets.UTF_8);
+            byte[] bodyPartBigBytes = data.getBytes(StandardCharsets.UTF_8);
             byte[] intermediaryBytes = ("\n--" + BOUNDARY +
                     "\nContent-Disposition: form-data; name=\"msg2\"; filename=\"file2.txt\"\n\n" +
-                    data).getBytes(CharsetUtil.UTF_8);
-            byte[] finalBigBytes = ("\n" + "--" + BOUNDARY + "--\n").getBytes(CharsetUtil.UTF_8);
+                    data).getBytes(StandardCharsets.UTF_8);
+            byte[] finalBigBytes = ("\n" + "--" + BOUNDARY + "--\n").getBytes(StandardCharsets.UTF_8);
 
             bodyStartBytesSupplier = BufferAllocator.onHeapUnpooled().constBufferSupplier(bodyStartBytes);
             finalBigBytesSupplier = BufferAllocator.onHeapUnpooled().constBufferSupplier(finalBigBytes);

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/AbstractMemoryHttpData.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/AbstractMemoryHttpData.java
@@ -18,7 +18,7 @@ package io.netty.contrib.handler.codec.http.multipart;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.CompositeBuffer;
 import io.netty5.buffer.api.DefaultBufferAllocators;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.handler.codec.http.HttpConstants;
 import io.netty5.util.internal.ObjectUtil;
 
@@ -269,7 +269,7 @@ public abstract class AbstractMemoryHttpData extends AbstractHttpData {
 
     @Override
     protected RuntimeException createResourceClosedException() {
-        return Statics.bufferIsClosed(getBuffer());
+        return InternalBufferUtils.bufferIsClosed(getBuffer());
     }
 
 }

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/Helpers.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/Helpers.java
@@ -25,7 +25,7 @@ import java.nio.charset.Charset;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.netty5.util.CharsetUtil.US_ASCII;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**
  * Various helper methods used by multipart implementation classes.

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -20,7 +20,7 @@ import io.netty.contrib.handler.codec.http.multipart.HttpPostRequestDecoder.EndO
 import io.netty.contrib.handler.codec.http.multipart.HttpPostRequestDecoder.ErrorDataDecoderException;
 import io.netty.contrib.handler.codec.http.multipart.HttpPostRequestDecoder.MultiPartStatus;
 import io.netty.contrib.handler.codec.http.multipart.HttpPostRequestDecoder.NotEnoughDataDecoderException;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.internal.PlatformDependent;
 import io.netty5.util.internal.StringUtil;
 import io.netty5.buffer.api.Buffer;
@@ -864,9 +864,9 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
                 throw new ErrorDataDecoderException(e);
             }
             if (code.equals(HttpPostBodyUtil.TransferEncodingMechanism.BIT7.value())) {
-                localCharset = CharsetUtil.US_ASCII;
+                localCharset = StandardCharsets.US_ASCII;
             } else if (code.equals(HttpPostBodyUtil.TransferEncodingMechanism.BIT8.value())) {
-                localCharset = CharsetUtil.ISO_8859_1;
+                localCharset = StandardCharsets.ISO_8859_1;
                 mechanism = TransferEncodingMechanism.BIT8;
             } else if (code.equals(HttpPostBodyUtil.TransferEncodingMechanism.BINARY.value())) {
                 // no real charset, so let the default

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/MemoryAttribute.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/MemoryAttribute.java
@@ -18,7 +18,7 @@ package io.netty.contrib.handler.codec.http.multipart;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.DefaultBufferAllocators;
 import io.netty5.buffer.api.Owned;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.channel.ChannelException;
 import io.netty5.handler.codec.http.HttpConstants;
 import io.netty5.util.Send;
@@ -167,6 +167,6 @@ public class MemoryAttribute extends AbstractMemoryHttpData implements Attribute
 
     @Override
     protected RuntimeException createResourceClosedException() {
-        return Statics.bufferIsClosed(getBuffer());
+        return InternalBufferUtils.bufferIsClosed(getBuffer());
     }
 }

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/AbstractDiskHttpDataTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/AbstractDiskHttpDataTest.java
@@ -28,7 +28,7 @@ import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static io.netty5.util.CharsetUtil.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/AbstractMemoryHttpDataTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/AbstractMemoryHttpDataTest.java
@@ -32,7 +32,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static io.netty5.util.CharsetUtil.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
 
 /** {@link AbstractMemoryHttpData} test cases. */

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/DefaultHttpDataFactoryTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/DefaultHttpDataFactoryTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static io.netty.contrib.handler.codec.http.multipart.HttpPostBodyUtil.DEFAULT_TEXT_CONTENT_TYPE;
-import static io.netty5.util.CharsetUtil.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static io.netty5.handler.codec.http.HttpHeaderValues.IDENTITY;
 import static io.netty5.handler.codec.http.HttpMethod.POST;
 import static io.netty5.handler.codec.http.HttpVersion.HTTP_1_1;

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/DiskFileUploadTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/DiskFileUploadTest.java
@@ -16,7 +16,7 @@
 package io.netty.contrib.handler.codec.http.multipart;
 
 import io.netty5.buffer.BufferInputStream;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.internal.PlatformDependent;
 import io.netty5.buffer.BufferUtil;
 import io.netty5.buffer.api.Buffer;
@@ -140,7 +140,7 @@ public class DiskFileUploadTest {
     public void testSetContentFromByteBuf() throws Exception {
         try (DiskFileUpload f1 = new DiskFileUpload("file2", "file2", "application/json", null, null, 0)) {
             String json = "{\"hello\":\"world\"}";
-            byte[] bytes = json.getBytes(CharsetUtil.UTF_8);
+            byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
             f1.setContent(Helpers.copiedBuffer(bytes));
             assertEquals(json, f1.getString());
             assertArrayEquals(bytes, f1.get());
@@ -154,7 +154,7 @@ public class DiskFileUploadTest {
     public void testSetContentFromInputStream() throws Exception {
         String json = "{\"hello\":\"world\",\"foo\":\"bar\"}";
         try (DiskFileUpload f1 = new DiskFileUpload("file3", "file3", "application/json", null, null, 0)) {
-            byte[] bytes = json.getBytes(CharsetUtil.UTF_8);
+            byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
 
             try (Buffer buf = Helpers.copiedBuffer(bytes);
                  InputStream is = new BufferInputStream(buf.send())) {
@@ -223,7 +223,7 @@ public class DiskFileUploadTest {
     @Test
     public void testDelete() throws Exception {
         String json = "{\"foo\":\"bar\"}";
-        byte[] bytes = json.getBytes(CharsetUtil.UTF_8);
+        byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
         File tmpFile = null;
         DiskFileUpload f1 = new DiskFileUpload("file4", "file4", "application/json", null, null, 0);
         try (f1) {

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpDataTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpDataTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.http.multipart;
 
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.DefaultBufferAllocators;
 import org.assertj.core.api.ThrowableAssert;
@@ -48,11 +48,11 @@ class HttpDataTest {
     static HttpData[] data() {
         return new HttpData[]{
                 new MemoryAttribute("test", 10),
-                new MemoryFileUpload("test", "", "text/plain", null, CharsetUtil.UTF_8, 10),
+                new MemoryFileUpload("test", "", "text/plain", null, StandardCharsets.UTF_8, 10),
                 new MixedAttribute("test", 10, -1),
-                new MixedFileUpload("test", "", "text/plain", null, CharsetUtil.UTF_8, 10, -1),
+                new MixedFileUpload("test", "", "text/plain", null, StandardCharsets.UTF_8, 10, -1),
                 new DiskAttribute("test", 10),
-                new DiskFileUpload("test", "", "text/plain", null, CharsetUtil.UTF_8, 10)
+                new DiskFileUpload("test", "", "text/plain", null, StandardCharsets.UTF_8, 10)
         };
     }
 
@@ -71,12 +71,12 @@ class HttpDataTest {
 
     @ParameterizedHttpDataTest
     void testCompletedFlagPreservedAfterRetainDuplicate(HttpData httpData) throws IOException {
-        httpData.addContent(Helpers.copiedBuffer("foo".getBytes(CharsetUtil.UTF_8)), false);
+        httpData.addContent(Helpers.copiedBuffer("foo".getBytes(StandardCharsets.UTF_8)), false);
         assertThat(httpData.isCompleted()).isFalse();
         HttpData duplicate = httpData.replace(httpData.content().split());
         assertThat(duplicate.isCompleted()).isFalse();
         duplicate.close();
-        httpData.addContent(Helpers.copiedBuffer("bar".getBytes(CharsetUtil.UTF_8)), true);
+        httpData.addContent(Helpers.copiedBuffer("bar".getBytes(StandardCharsets.UTF_8)), true);
         assertThat(httpData.isCompleted()).isTrue();
         duplicate = httpData.replace(httpData.content().split());
         assertThat(duplicate.isCompleted()).isTrue();
@@ -86,14 +86,14 @@ class HttpDataTest {
     @Test
     void testAddContentExceedsDefinedSizeDiskFileUpload() {
         doTestAddContentExceedsSize(
-                new DiskFileUpload("test", "", "application/json", null, CharsetUtil.UTF_8, 10),
+                new DiskFileUpload("test", "", "application/json", null, StandardCharsets.UTF_8, 10),
                 "Out of size: 64 > 10");
     }
 
     @Test
     void testAddContentExceedsDefinedSizeMemoryFileUpload() {
         doTestAddContentExceedsSize(
-                new MemoryFileUpload("test", "", "application/json", null, CharsetUtil.UTF_8, 10),
+                new MemoryFileUpload("test", "", "application/json", null, StandardCharsets.UTF_8, 10),
                 "Out of size: 64 > 10");
     }
 
@@ -138,7 +138,7 @@ class HttpDataTest {
 
     @Test
     void testMemoryFileUploadSend() throws IOException {
-        try (MemoryFileUpload mem = new MemoryFileUpload("test", "filename", "text/plain", "BINARY", CharsetUtil.UTF_8, 10)) {
+        try (MemoryFileUpload mem = new MemoryFileUpload("test", "filename", "text/plain", "BINARY", StandardCharsets.UTF_8, 10)) {
             mem.addContent(Helpers.copiedBuffer("content", Charset.defaultCharset()), false);
             mem.setMaxSize(100);
             assertThat(mem.isCompleted()).isFalse();
@@ -150,7 +150,7 @@ class HttpDataTest {
                 assertThat(memSend.getString()).isEqualTo("content");
                 assertThat(memSend.getHttpDataType()).isEqualTo(InterfaceHttpData.HttpDataType.FileUpload);
                 assertThat(memSend.isInMemory()).isTrue();
-                assertThat(memSend.getCharset()).isEqualTo(CharsetUtil.UTF_8);
+                assertThat(memSend.getCharset()).isEqualTo(StandardCharsets.UTF_8);
                 assertThat(memSend.definedLength()).isEqualTo(10);
                 assertThat(memSend.getMaxSize()).isEqualTo(100);
                 assertThat(memSend.getName()).isEqualTo("test");
@@ -165,7 +165,7 @@ class HttpDataTest {
 
     @Test
     void testMixedAttributeSend() throws IOException {
-        try (MixedAttribute data = new MixedAttribute("test", 10, 100, CharsetUtil.UTF_8, "/tmp", true)) {
+        try (MixedAttribute data = new MixedAttribute("test", 10, 100, StandardCharsets.UTF_8, "/tmp", true)) {
             data.addContent(Helpers.copiedBuffer("content", Charset.defaultCharset()), false);
             data.setMaxSize(1000);
             assertThat(data.isCompleted()).isFalse();
@@ -177,7 +177,7 @@ class HttpDataTest {
                 assertThat(send.getValue()).isEqualTo("content");
                 assertThat(send.getHttpDataType()).isEqualTo(InterfaceHttpData.HttpDataType.Attribute);
                 assertThat(send.isInMemory()).isTrue();
-                assertThat(send.getCharset()).isEqualTo(CharsetUtil.UTF_8);
+                assertThat(send.getCharset()).isEqualTo(StandardCharsets.UTF_8);
                 assertThat(send.definedLength()).isEqualTo(10);
                 assertThat(send.getMaxSize()).isEqualTo(1000);
                 assertThat(send.limitSize).isEqualTo(100);
@@ -191,7 +191,7 @@ class HttpDataTest {
     @Test
     void testMixedFileUploadSend() throws IOException {
         try (MixedFileUpload data = new MixedFileUpload("test", "filename", "text/plain", "BINARY",
-                CharsetUtil.UTF_8, 10, 100, "/tmp", true)) {
+                StandardCharsets.UTF_8, 10, 100, "/tmp", true)) {
             data.addContent(Helpers.copiedBuffer("content", Charset.defaultCharset()), false);
             data.setMaxSize(1000);
             assertThat(data.isCompleted()).isFalse();
@@ -242,7 +242,7 @@ class HttpDataTest {
     @Test
     void testDiskFileUploadSend() throws IOException {
 
-        try (DiskFileUpload data = new DiskFileUpload("test", "", "text/plain", null, CharsetUtil.UTF_8, 10, "/tmp", true)) {
+        try (DiskFileUpload data = new DiskFileUpload("test", "", "text/plain", null, StandardCharsets.UTF_8, 10, "/tmp", true)) {
             data.addContent(Helpers.copiedBuffer("content", Charset.defaultCharset()), false);
             data.setMaxSize(1000);
             assertThat(data.isCompleted()).isFalse();

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.http.multipart;
 
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.DefaultBufferAllocators;
 import io.netty5.handler.codec.http.DefaultFullHttpRequest;
@@ -75,7 +75,7 @@ public class HttpPostMultiPartRequestDecoderTest {
                         "--861fbeab-cd20-470c-9609-d40a0f704466--\n";
 
         FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload",
-                Helpers.copiedBuffer(content, CharsetUtil.US_ASCII));
+                Helpers.copiedBuffer(content, StandardCharsets.US_ASCII));
         req.headers().set("content-type", "multipart/form-data; boundary=861fbeab-cd20-470c-9609-d40a0f704466");
         req.headers().set("content-length", content.length());
 
@@ -93,7 +93,7 @@ public class HttpPostMultiPartRequestDecoderTest {
     public void testDelimiterExceedLeftSpaceInCurrentBuffer() throws IOException {
         String delimiter = "--861fbeab-cd20-470c-9609-d40a0f704466";
         String suffix = '\n' + delimiter + "--\n";
-        byte[] bsuffix = suffix.getBytes(CharsetUtil.UTF_8);
+        byte[] bsuffix = suffix.getBytes(StandardCharsets.UTF_8);
         int partOfDelimiter = bsuffix.length / 2;
         int bytesLastChunk = 355 - partOfDelimiter; // to try to have an out of bound since content is > delimiter
         byte[] bsuffix1 = Arrays.copyOf(bsuffix, partOfDelimiter);
@@ -109,7 +109,7 @@ public class HttpPostMultiPartRequestDecoderTest {
         // Factory using Memory mode
         HttpDataFactory factory = new DefaultHttpDataFactory(false);
         HttpPostMultipartRequestDecoder decoder = new HttpPostMultipartRequestDecoder(factory, request);
-        Buffer buf = Helpers.copiedBuffer(prefix.getBytes(CharsetUtil.UTF_8));
+        Buffer buf = Helpers.copiedBuffer(prefix.getBytes(StandardCharsets.UTF_8));
         DefaultHttpContent httpContent = new DefaultHttpContent(buf);
         decoder.offer(httpContent);
         assertNotNull((HttpData) decoder.currentPartialHttpData());
@@ -163,7 +163,7 @@ public class HttpPostMultiPartRequestDecoderTest {
         request.headers().set("content-length", prefix.length() + fileSize + suffix.length());
 
         HttpPostMultipartRequestDecoder decoder = new HttpPostMultipartRequestDecoder(factory, request);
-        Buffer buf = Helpers.copiedBuffer(prefix.getBytes(CharsetUtil.UTF_8));
+        Buffer buf = Helpers.copiedBuffer(prefix.getBytes(StandardCharsets.UTF_8));
         DefaultHttpContent httpContent = new DefaultHttpContent(buf);
         decoder.offer(httpContent);
         assertNotNull(((HttpData) decoder.currentPartialHttpData()).getBuffer());
@@ -182,9 +182,9 @@ public class HttpPostMultiPartRequestDecoderTest {
             httpContent.close();
         }
 
-        byte[] bsuffix1 = suffix1.getBytes(CharsetUtil.UTF_8);
+        byte[] bsuffix1 = suffix1.getBytes(StandardCharsets.UTF_8);
         byte[] previousLastbody = new byte[bytesLastChunk - bsuffix1.length];
-        byte[] bdelimiter = delimiter.getBytes(CharsetUtil.UTF_8);
+        byte[] bdelimiter = delimiter.getBytes(StandardCharsets.UTF_8);
         byte[] lastbody = new byte[2 * bsuffix1.length];
         Arrays.fill(previousLastbody, (byte) 1);
         previousLastbody[0] = HttpConstants.CR;
@@ -210,7 +210,7 @@ public class HttpPostMultiPartRequestDecoderTest {
         decoder.offer(httpContent);
         assertNotNull(((HttpData) decoder.currentPartialHttpData()).getBuffer());
         httpContent.close();
-        content2 = Helpers.copiedBuffer(suffix2.getBytes(CharsetUtil.UTF_8));
+        content2 = Helpers.copiedBuffer(suffix2.getBytes(StandardCharsets.UTF_8));
         httpContent = new DefaultHttpContent(content2);
         decoder.offer(httpContent);
         assertNull(decoder.currentPartialHttpData());
@@ -283,7 +283,7 @@ public class HttpPostMultiPartRequestDecoderTest {
                 "\r\n\u0001\u0002\u0003\u0004\r\n--861fbeab-cd20-470c-9609-d40a0f704466--\r\n\",\n";
 
         FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload",
-                Helpers.copiedBuffer(content, CharsetUtil.US_ASCII));
+                Helpers.copiedBuffer(content, StandardCharsets.US_ASCII));
         req.headers().set("content-type", "multipart/form-data; boundary=861fbeab-cd20-470c-9609-d40a0f704466");
         req.headers().set("content-length", content.length());
 
@@ -315,13 +315,13 @@ public class HttpPostMultiPartRequestDecoderTest {
         HttpPostMultipartRequestDecoder decoder = new HttpPostMultipartRequestDecoder(factory, request);
         decoder.setDiscardThreshold(maxMemory);
         for (int rank = 0; rank < nbItems; rank++) {
-            byte[] bp1 = prefix1.getBytes(CharsetUtil.UTF_8);
-            byte[] bp2 = prefix2.getBytes(CharsetUtil.UTF_8);
+            byte[] bp1 = prefix1.getBytes(StandardCharsets.UTF_8);
+            byte[] bp2 = prefix2.getBytes(StandardCharsets.UTF_8);
             byte[] prefix = new byte[bp1.length + 2 + bp2.length];
             for (int i = 0; i < bp1.length; i++) {
                 prefix[i] = bp1[i];
             }
-            byte[] brank = Integer.toString(10 + rank).getBytes(CharsetUtil.UTF_8);
+            byte[] brank = Integer.toString(10 + rank).getBytes(StandardCharsets.UTF_8);
             prefix[bp1.length] = brank[0];
             prefix[bp1.length + 1] = brank[1];
             for (int i = 0; i < bp2.length; i++) {
@@ -338,7 +338,7 @@ public class HttpPostMultiPartRequestDecoderTest {
             decoder.offer(httpContent);
             httpContent.close();
         }
-        byte[] lastbody = suffix.getBytes(CharsetUtil.UTF_8);
+        byte[] lastbody = suffix.getBytes(StandardCharsets.UTF_8);
         Buffer content2 = Helpers.copiedBuffer(lastbody, 0, lastbody.length);
         DefaultHttpContent httpContent = new DefaultHttpContent(content2);
         decoder.offer(httpContent);
@@ -379,7 +379,7 @@ public class HttpPostMultiPartRequestDecoderTest {
                         "\n";
 
         String suffix = "--861fbeab-cd20-470c-9609-d40a0f704466--";
-        byte[] bsuffix = suffix.getBytes(CharsetUtil.UTF_8);
+        byte[] bsuffix = suffix.getBytes(StandardCharsets.UTF_8);
         byte[] bsuffixReal = new byte[bsuffix.length + 2];
         for (int i = 0; i < bsuffix.length; i++) {
             bsuffixReal[1 + i] = bsuffix[i];
@@ -394,7 +394,7 @@ public class HttpPostMultiPartRequestDecoderTest {
         request.headers().set("content-length", prefix.length() + fileSize + suffix.length() + 4);
 
         HttpPostMultipartRequestDecoder decoder = new HttpPostMultipartRequestDecoder(factory, request);
-        Buffer buf = Helpers.copiedBuffer(prefix.getBytes(CharsetUtil.UTF_8));
+        Buffer buf = Helpers.copiedBuffer(prefix.getBytes(StandardCharsets.UTF_8));
         DefaultHttpContent httpContent = new DefaultHttpContent(buf);
         decoder.offer(httpContent);
         assertNotNull(((HttpData) decoder.currentPartialHttpData()).getBuffer());

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -30,7 +30,7 @@ import io.netty5.handler.codec.http.HttpMethod;
 import io.netty5.handler.codec.http.HttpRequest;
 import io.netty5.handler.codec.http.HttpVersion;
 import io.netty5.handler.codec.http.LastHttpContent;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -88,7 +88,7 @@ public class HttpPostRequestDecoderTest {
             // Create decoder instance to test.
             final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
 
-            Buffer buf = Helpers.copiedBuffer(body, CharsetUtil.UTF_8);
+            Buffer buf = Helpers.copiedBuffer(body, StandardCharsets.UTF_8);
             decoder.offer(new DefaultHttpContent(buf));
             decoder.offer(new DefaultHttpContent(DefaultBufferAllocators.preferredAllocator().allocate(0)));
 
@@ -99,7 +99,7 @@ public class HttpPostRequestDecoderTest {
             MemoryFileUpload upload = (MemoryFileUpload) decoder.next();
 
             // Validate data has been parsed correctly as it was passed into request.
-            assertEquals(data, upload.getString(CharsetUtil.UTF_8),
+            assertEquals(data, upload.getString(StandardCharsets.UTF_8),
                     "Invalid decoded data [data=" + data.replaceAll("\r", "\\\\r") + ", upload=" + upload + ']');
             upload.close();
             decoder.destroy();
@@ -131,7 +131,7 @@ public class HttpPostRequestDecoderTest {
                             data + "\r\n" +
                             "--" + boundary + "--\r\n";
 
-            req.payload().writeBytes(body.getBytes(CharsetUtil.UTF_8));
+            req.payload().writeBytes(body.getBytes(StandardCharsets.UTF_8));
         }
         // Create decoder instance to test.
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
@@ -171,7 +171,7 @@ public class HttpPostRequestDecoderTest {
                             datas[i] + "\r\n" +
                             "--" + boundary + "--\r\n";
 
-            req.payload().writeBytes(body.getBytes(CharsetUtil.UTF_8));
+            req.payload().writeBytes(body.getBytes(StandardCharsets.UTF_8));
             // Create decoder instance to test.
             final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
             assertFalse(decoder.getBodyHttpDatas().isEmpty());
@@ -181,7 +181,7 @@ public class HttpPostRequestDecoderTest {
             Attribute attribute = (Attribute) httpdata;
             byte[] datar = attribute.get();
             assertNotNull(datar);
-            assertEquals(datas[i].getBytes(CharsetUtil.UTF_8).length, datar.length);
+            assertEquals(datas[i].getBytes(StandardCharsets.UTF_8).length, datar.length);
 
             decoder.destroy();
             req.close();
@@ -212,7 +212,7 @@ public class HttpPostRequestDecoderTest {
                             data + "\r\n" +
                             "--" + boundary + "--\r\n";
 
-            req.payload().writeBytes(body.getBytes(CharsetUtil.UTF_8));
+            req.payload().writeBytes(body.getBytes(StandardCharsets.UTF_8));
         }
         // Create decoder instance to test.
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
@@ -373,7 +373,7 @@ public class HttpPostRequestDecoderTest {
                         data + "\r\n" +
                         "--" + boundary + "--\r\n";
 
-        req.payload().writeBytes(body.getBytes(CharsetUtil.UTF_8.name()));
+        req.payload().writeBytes(body.getBytes(StandardCharsets.UTF_8.name()));
         // Create decoder instance to test.
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
@@ -399,7 +399,7 @@ public class HttpPostRequestDecoderTest {
                         data + "\r\n" +
                         "--" + boundary + "--\r\n";
 
-        req.payload().writeBytes(body.getBytes(CharsetUtil.UTF_8.name()));
+        req.payload().writeBytes(body.getBytes(StandardCharsets.UTF_8.name()));
         // Create decoder instance to test.
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
@@ -433,7 +433,7 @@ public class HttpPostRequestDecoderTest {
                             data + "\r\n" +
                             "--" + boundary + "--\r\n";
 
-            req.payload().writeBytes(body.getBytes(CharsetUtil.UTF_8));
+            req.payload().writeBytes(body.getBytes(StandardCharsets.UTF_8));
         }
         // Create decoder instance to test without any exception.
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
@@ -493,7 +493,7 @@ public class HttpPostRequestDecoderTest {
                         data + "\r\n" +
                         "--" + boundary + "--\r\n";
 
-        req.payload().writeBytes(body.getBytes(CharsetUtil.UTF_8));
+        req.payload().writeBytes(body.getBytes(StandardCharsets.UTF_8));
         // Create decoder instance to test.
         try {
             new HttpPostRequestDecoder(inMemoryFactory, req);
@@ -526,7 +526,7 @@ public class HttpPostRequestDecoderTest {
                         "\r\n" +
                         "--" + boundary + "--\r\n";
 
-        req.payload().writeBytes(body.getBytes(CharsetUtil.UTF_8));
+        req.payload().writeBytes(body.getBytes(StandardCharsets.UTF_8));
         // Create decoder instance to test.
         try {
             new HttpPostRequestDecoder(inMemoryFactory, req);
@@ -541,7 +541,7 @@ public class HttpPostRequestDecoderTest {
     @Test
     public void testFormEncodeIncorrect() throws Exception {
         LastHttpContent content = new DefaultLastHttpContent(
-                Helpers.copiedBuffer("project=netty&=netty&project=netty", CharsetUtil.US_ASCII));
+                Helpers.copiedBuffer("project=netty&=netty&project=netty", StandardCharsets.US_ASCII));
         DefaultHttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
         HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(req);
         try {
@@ -708,7 +708,7 @@ public class HttpPostRequestDecoderTest {
                         data + "\r\n" +
                         "--" + boundary + "--\r\n";
 
-        req.payload().writeBytes(body.getBytes(CharsetUtil.UTF_8.name()));
+        req.payload().writeBytes(body.getBytes(StandardCharsets.UTF_8.name()));
         // Create decoder instance to test.
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
@@ -743,7 +743,7 @@ public class HttpPostRequestDecoderTest {
         HttpPostRequestDecoder decoder =
                 new HttpPostRequestDecoder(new DefaultHttpDataFactory(DefaultHttpDataFactory.MINSIZE),
                         req,
-                        CharsetUtil.UTF_8);
+                        StandardCharsets.UTF_8);
 
         assertTrue(decoder.isMultipart());
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
@@ -763,7 +763,7 @@ public class HttpPostRequestDecoderTest {
     @Test
     public void testNotLeak() {
         final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/",
-                Helpers.copiedBuffer("a=1&=2&b=3", CharsetUtil.US_ASCII));
+                Helpers.copiedBuffer("a=1&=2&b=3", StandardCharsets.US_ASCII));
         try {
             assertThrows(HttpPostRequestDecoder.ErrorDataDecoderException.class, new Executable() {
                 @Override
@@ -797,7 +797,7 @@ public class HttpPostRequestDecoderTest {
     }
 
     private static void testNotLeakWhenWrapIllegalArgumentException(Buffer buf) {
-        buf.writeCharSequence("a=b&foo=%22bar%22&==", CharsetUtil.US_ASCII);
+        buf.writeCharSequence("a=b&foo=%22bar%22&==", StandardCharsets.US_ASCII);
         FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/", buf);
         try {
             new HttpPostStandardRequestDecoder(request).destroy();
@@ -1002,7 +1002,7 @@ public class HttpPostRequestDecoderTest {
         byte[] bodyBytes = ("aaaa/bbbb=aaaaaaaaaa" +
                 "aaaaaaaaaaaaaaaaaaaaaaaaaa" +
                 "aaaaaaaaaaaaaaaaaaaaaaaaaa" +
-                "aaaaaaaaaaaaaaaaaaa").getBytes(CharsetUtil.US_ASCII);
+                "aaaaaaaaaaaaaaaaaaa").getBytes(StandardCharsets.US_ASCII);
         Buffer content = DefaultBufferAllocators.offHeapAllocator().allocate(bodyBytes.length);
         content.writeBytes(bodyBytes);
 

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestEncoderTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestEncoderTest.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.http.multipart;
 
 import io.netty.contrib.handler.codec.http.multipart.HttpPostRequestEncoder.EncoderMode;
 import io.netty.contrib.handler.codec.http.multipart.HttpPostRequestEncoder.ErrorDataEncoderException;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.internal.StringUtil;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
@@ -246,7 +246,7 @@ public class HttpPostRequestEncoderTest {
         DefaultHttpDataFactory factory = new DefaultHttpDataFactory(DefaultHttpDataFactory.MINSIZE);
 
         HttpPostRequestEncoder encoder = new HttpPostRequestEncoder(factory,
-                request, true, CharsetUtil.UTF_8, EncoderMode.HTML5);
+                request, true, StandardCharsets.UTF_8, EncoderMode.HTML5);
         File file1 = new File(getClass().getResource("/file-01.txt").toURI());
         File file2 = new File(getClass().getResource("/file-02.txt").toURI());
         encoder.addBodyAttribute("foo", "bar");
@@ -290,7 +290,7 @@ public class HttpPostRequestEncoderTest {
         DefaultHttpDataFactory factory = new DefaultHttpDataFactory(DefaultHttpDataFactory.MINSIZE);
 
         HttpPostRequestEncoder encoder = new HttpPostRequestEncoder(factory,
-                request, true, CharsetUtil.UTF_8, EncoderMode.HTML5);
+                request, true, StandardCharsets.UTF_8, EncoderMode.HTML5);
         File file1 = new File(getClass().getResource("/file-01.txt").toURI());
         encoder.addBodyAttribute("foo", "bar");
         encoder.addBodyFileUpload("quux", file1, "text/plain", false);
@@ -366,7 +366,7 @@ public class HttpPostRequestEncoderTest {
         }
 
         Buffer content = DefaultBufferAllocators.onHeapAllocator().compose(Stream.of(buffers).map(b -> b.send()).collect(Collectors.toList()));
-        String contentStr = content.toString(CharsetUtil.UTF_8);
+        String contentStr = content.toString(StandardCharsets.UTF_8);
         content.close();
         return contentStr;
     }
@@ -380,13 +380,13 @@ public class HttpPostRequestEncoderTest {
                 HttpConstants.DEFAULT_CHARSET, HttpPostRequestEncoder.EncoderMode.RFC1738);
 
         MemoryFileUpload first = new MemoryFileUpload("resources", "", "application/json", null,
-                CharsetUtil.UTF_8, -1);
+                StandardCharsets.UTF_8, -1);
         first.setMaxSize(-1);
         first.setContent(new ByteArrayInputStream(new byte[7955]));
         encoder.addBodyHttpData(first);
 
         MemoryFileUpload second = new MemoryFileUpload("resources2", "", "application/json", null,
-                CharsetUtil.UTF_8, -1);
+                StandardCharsets.UTF_8, -1);
         second.setMaxSize(-1);
         second.setContent(new ByteArrayInputStream(new byte[7928]));
         encoder.addBodyHttpData(second);

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
@@ -23,7 +23,7 @@ import io.netty5.handler.codec.http.DefaultLastHttpContent;
 import io.netty5.handler.codec.http.HttpMethod;
 import io.netty5.handler.codec.http.HttpRequest;
 import io.netty5.handler.codec.http.HttpVersion;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -37,7 +37,7 @@ class HttpPostStandardRequestDecoderTest {
         HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload");
 
         HttpPostStandardRequestDecoder decoder = new HttpPostStandardRequestDecoder(httpDiskDataFactory(), request);
-        Buffer buf = DefaultBufferAllocators.preferredAllocator().copyOf(requestBody.getBytes(CharsetUtil.UTF_8));
+        Buffer buf = DefaultBufferAllocators.preferredAllocator().copyOf(requestBody.getBytes(StandardCharsets.UTF_8));
         DefaultLastHttpContent httpContent = new DefaultLastHttpContent(buf);
         decoder.offer(httpContent);
 
@@ -54,7 +54,7 @@ class HttpPostStandardRequestDecoderTest {
         HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload");
 
         HttpPostStandardRequestDecoder decoder = new HttpPostStandardRequestDecoder(httpDiskDataFactory(), request);
-        Buffer buf = DefaultBufferAllocators.preferredAllocator().copyOf(requestBody.getBytes(CharsetUtil.UTF_8));
+        Buffer buf = DefaultBufferAllocators.preferredAllocator().copyOf(requestBody.getBytes(StandardCharsets.UTF_8));
         DefaultLastHttpContent httpContent = new DefaultLastHttpContent(buf);
         decoder.offer(httpContent);
 
@@ -70,7 +70,7 @@ class HttpPostStandardRequestDecoderTest {
         HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload");
 
         HttpPostStandardRequestDecoder decoder = new HttpPostStandardRequestDecoder(httpDiskDataFactory(), request);
-        Buffer buf = DefaultBufferAllocators.preferredAllocator().copyOf(requestBody.getBytes(CharsetUtil.UTF_8));
+        Buffer buf = DefaultBufferAllocators.preferredAllocator().copyOf(requestBody.getBytes(StandardCharsets.UTF_8));
         DefaultLastHttpContent httpContent = new DefaultLastHttpContent(buf);
         decoder.offer(httpContent);
 

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/MixedTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/MixedTest.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.http.multipart;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.DefaultBufferAllocators;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +44,7 @@ public class MixedTest {
 
     @Test
     public void mixedFileUploadClosed() throws IOException {
-        MixedFileUpload upload = new MixedFileUpload("foo", "foo", "foo", "UTF-8", CharsetUtil.UTF_8, 0, 100);
+        MixedFileUpload upload = new MixedFileUpload("foo", "foo", "foo", "UTF-8", StandardCharsets.UTF_8, 0, 100);
         byte[] bytes1 = new byte[90];
         Buffer buf1 = DefaultBufferAllocators.onHeapAllocator().allocate(bytes1.length);
         buf1.writeBytes(bytes1);

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/http/multipart/HttpUploadClientHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/http/multipart/HttpUploadClientHandler.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.example.http.multipart;
 
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.SimpleChannelInboundHandler;
 import io.netty5.handler.codec.http.HttpContent;
@@ -56,7 +56,7 @@ public class HttpUploadClientHandler extends SimpleChannelInboundHandler<HttpObj
         }
         if (msg instanceof HttpContent) {
             HttpContent chunk = (HttpContent) msg;
-            System.err.println(chunk.payload().toString(CharsetUtil.UTF_8));
+            System.err.println(chunk.payload().toString(StandardCharsets.UTF_8));
 
             if (chunk instanceof LastHttpContent) {
                 if (readingChunks) {
@@ -66,7 +66,7 @@ public class HttpUploadClientHandler extends SimpleChannelInboundHandler<HttpObj
                 }
                 readingChunks = false;
             } else {
-                System.err.println(chunk.payload().toString(CharsetUtil.UTF_8));
+                System.err.println(chunk.payload().toString(StandardCharsets.UTF_8));
             }
         }
     }

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/http/multipart/HttpUploadServerHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/http/multipart/HttpUploadServerHandler.java
@@ -25,7 +25,7 @@ import io.netty.contrib.handler.codec.http.multipart.HttpDataFactory;
 import io.netty.contrib.handler.codec.http.multipart.HttpPostRequestDecoder;
 import io.netty.contrib.handler.codec.http.multipart.InterfaceHttpData;
 import io.netty.contrib.handler.codec.http.multipart.InterfaceHttpData.HttpDataType;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelFutureListeners;
@@ -307,7 +307,7 @@ public class HttpUploadServerHandler extends SimpleChannelInboundHandler<HttpObj
     private void writeResponse(ChannelHandlerContext ctx, boolean forceClose) {
         Channel channel = ctx.channel();
         // Convert the response content to a ChannelBuffer.
-        Buffer buf = channel.bufferAllocator().copyOf(responseContent.toString(), CharsetUtil.UTF_8);
+        Buffer buf = channel.bufferAllocator().copyOf(responseContent.toString(), StandardCharsets.UTF_8);
         responseContent.setLength(0);
 
         // Decide whether to close the connection or not.
@@ -418,7 +418,7 @@ public class HttpUploadServerHandler extends SimpleChannelInboundHandler<HttpObj
         responseContent.append("</body>");
         responseContent.append("</html>");
 
-        Buffer buf = ctx.bufferAllocator().copyOf(responseContent.toString(), CharsetUtil.UTF_8);
+        Buffer buf = ctx.bufferAllocator().copyOf(responseContent.toString(), StandardCharsets.UTF_8);
         // Build the response object.
         FullHttpResponse response = new DefaultFullHttpResponse(
                 HttpVersion.HTTP_1_1, HttpResponseStatus.OK, buf);


### PR DESCRIPTION
Motivation:
We need to adapt to the following netty PR changes:

- Rename Statics to InternalBufferUtils ([#12739](https://github.com/netty/netty/pull/12739))
- Remove Charset constants from CharsetUtil ([12741](https://github.com/netty/netty/pull/12741))

Modification:
Netty CharsetUtil needs to be replaced by java.nio.charset.StandardCharsets and Statics by InternalBufferUtils

Result:
The build can now be done