### PR TITLE
Simplify buffer ownership for HttpData getBuffer/getContent methods

### DIFF
--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -24,6 +24,7 @@ import io.netty5.util.internal.ObjectUtil;
 import io.netty5.util.internal.PlatformDependent;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
+import io.netty.contrib.handler.codec.http.multipart.Helpers.ThrowingConsumer;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,7 +34,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
-import java.util.function.Consumer;
 
 /**
  * Abstract Disk HttpData implementation
@@ -303,11 +303,11 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
     }
 
     @Override
-    public void withBuffer(Consumer<Buffer> bufferConsumer) throws IOException {
+    public <E extends Exception> void usingBuffer(ThrowingConsumer<Buffer, E> callback) throws IOException, E {
         checkAccessible();
         Buffer buf = getContent();
         try {
-            bufferConsumer.accept(buf);
+            callback.accept(buf);
         }
         finally {
             // check if the callback closed the buffer before closing it.

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/AbstractHttpData.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/AbstractHttpData.java
@@ -21,10 +21,10 @@ import io.netty5.buffer.internal.ResourceSupport;
 import io.netty5.channel.ChannelException;
 import io.netty5.handler.codec.http.HttpConstants;
 import io.netty5.util.internal.ObjectUtil;
+import io.netty.contrib.handler.codec.http.multipart.Helpers.ThrowingConsumer;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 import static io.netty5.util.internal.ObjectUtil.checkNonEmpty;
@@ -141,10 +141,10 @@ public abstract class AbstractHttpData extends ResourceSupport<HttpData, Abstrac
     }
 
     @Override
-    public void withContent(Consumer<Buffer> bufferConsumer) {
+    public <E extends Exception> void usingContent(ThrowingConsumer<Buffer, E> callback) throws E {
         checkAccessible();
         try {
-            withBuffer(b -> bufferConsumer.accept(b));
+            usingBuffer(b -> callback.accept(b));
         } catch (IOException e) {
             throw new ChannelException(e);
         }

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/AbstractHttpData.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/AbstractHttpData.java
@@ -24,6 +24,7 @@ import io.netty5.util.internal.ObjectUtil;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 import static io.netty5.util.internal.ObjectUtil.checkNonEmpty;
@@ -140,10 +141,10 @@ public abstract class AbstractHttpData extends ResourceSupport<HttpData, Abstrac
     }
 
     @Override
-    public Buffer content() {
+    public void withContent(Consumer<Buffer> bufferConsumer) {
         checkAccessible();
         try {
-            return getBuffer();
+            withBuffer(b -> bufferConsumer.accept(b));
         } catch (IOException e) {
             throw new ChannelException(e);
         }

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/AbstractMemoryHttpData.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/AbstractMemoryHttpData.java
@@ -21,6 +21,7 @@ import io.netty5.buffer.DefaultBufferAllocators;
 import io.netty5.buffer.internal.InternalBufferUtils;
 import io.netty5.handler.codec.http.HttpConstants;
 import io.netty5.util.internal.ObjectUtil;
+import io.netty.contrib.handler.codec.http.multipart.Helpers.ThrowingConsumer;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,7 +30,6 @@ import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.function.Consumer;
 
 /**
  * Abstract Memory HttpData implementation
@@ -222,8 +222,8 @@ public abstract class AbstractMemoryHttpData extends AbstractHttpData {
      * @return the attached ByteBuf containing the actual bytes
      */
     @Override
-    public void withBuffer(Consumer<Buffer> bufferConsumer) {
-        bufferConsumer.accept(byteBuf);
+    public <E extends Exception> void usingBuffer(ThrowingConsumer<Buffer, E> callback) throws IOException, E {
+        callback.accept(byteBuf);
     }
 
     @Override

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/AbstractMemoryHttpData.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/AbstractMemoryHttpData.java
@@ -29,13 +29,14 @@ import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.function.Consumer;
 
 /**
  * Abstract Memory HttpData implementation
  */
 public abstract class AbstractMemoryHttpData extends AbstractHttpData {
 
-    private Buffer byteBuf;
+    protected Buffer byteBuf;
 
     protected AbstractMemoryHttpData(String name, Charset charset, long size) {
         super(name, charset, size);
@@ -221,8 +222,8 @@ public abstract class AbstractMemoryHttpData extends AbstractHttpData {
      * @return the attached ByteBuf containing the actual bytes
      */
     @Override
-    public Buffer getBuffer() {
-        return byteBuf;
+    public void withBuffer(Consumer<Buffer> bufferConsumer) {
+        bufferConsumer.accept(byteBuf);
     }
 
     @Override
@@ -272,7 +273,7 @@ public abstract class AbstractMemoryHttpData extends AbstractHttpData {
 
     @Override
     protected RuntimeException createResourceClosedException() {
-        return InternalBufferUtils.bufferIsClosed(getBuffer());
+        return InternalBufferUtils.bufferIsClosed(byteBuf);
     }
 
 }

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/AbstractMixedHttpData.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/AbstractMixedHttpData.java
@@ -18,14 +18,12 @@ package io.netty.contrib.handler.codec.http.multipart;
 import io.netty5.buffer.Buffer;
 import io.netty5.buffer.Drop;
 import io.netty5.buffer.internal.ResourceSupport;
+import io.netty.contrib.handler.codec.http.multipart.Helpers.ThrowingConsumer;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.util.function.Consumer;
-
-import static io.netty.contrib.handler.codec.http.multipart.Helpers.ThrowingConsumer.unchecked;
 
 abstract class AbstractMixedHttpData<D extends HttpData> extends ResourceSupport<HttpData, AbstractMixedHttpData<? extends HttpData>> implements HttpData {
     final String baseDir;
@@ -72,8 +70,8 @@ abstract class AbstractMixedHttpData<D extends HttpData> extends ResourceSupport
     }
 
     @Override
-    public void withContent(Consumer<Buffer> bufferConsumer) {
-        wrapped.withContent(bufferConsumer);
+    public <E extends Exception> void usingContent(ThrowingConsumer<Buffer, E> callback) throws E {
+        wrapped.usingContent(callback);
     }
 
     @Override
@@ -108,11 +106,11 @@ abstract class AbstractMixedHttpData<D extends HttpData> extends ResourceSupport
                     // Because the diskData.addContent method throws an exception, use
                     // the Helpers.ThrowingConsumer.unchecked helper which allows
                     // to wrap a throwing consumer into a regular consumer
-                    ((AbstractMemoryHttpData) wrapped).withBuffer(unchecked(data -> {
+                    ((AbstractMemoryHttpData) wrapped).usingBuffer(data -> {
                         if (data != null && data.readableBytes() > 0) {
                             diskData.addContent(data, false); // data will be closed by this method
                         }
-                    }));
+                    });
                     wrapped.close();
                     wrapped = diskData;
                 }
@@ -135,8 +133,8 @@ abstract class AbstractMixedHttpData<D extends HttpData> extends ResourceSupport
     }
 
     @Override
-    public void withBuffer(Consumer<Buffer> bufferConsumer) throws IOException {
-        wrapped.withBuffer(bufferConsumer);
+    public <E extends Exception> void usingBuffer(ThrowingConsumer<Buffer, E> callback) throws IOException, E {
+        wrapped.usingBuffer(callback);
     }
 
     @Override

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/DiskAttribute.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/DiskAttribute.java
@@ -210,8 +210,7 @@ public class DiskAttribute extends AbstractDiskHttpData implements Attribute {
 
     @Override
     public Attribute copy() {
-        checkAccessible();
-        return replace(content()); // for disk based content, content() always return a copy
+        return replace(getContent()); // for disk based content, getContent() always returns a copy
     }
 
     @Override

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/DiskFileUpload.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/DiskFileUpload.java
@@ -178,7 +178,7 @@ public class DiskFileUpload extends AbstractDiskHttpData implements FileUpload {
 
     @Override
     public FileUpload copy() {
-        return replace(content()); // for disk based content, content() always return a copy
+        return replace(getContent()); // for disk based content, getContent() always returns a copy
     }
 
     @Override

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/Helpers.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/Helpers.java
@@ -22,6 +22,7 @@ import io.netty5.util.AsciiString;
 import io.netty5.util.Resource;
 
 import java.nio.charset.Charset;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -31,6 +32,48 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
  * Various helper methods used by multipart implementation classes.
  */
 public class Helpers {
+
+    /**
+     * A Consumer which can throw Exceptions. This utility class can be used to
+     * wrap a throwing consumer into a regular java Consumer, and allows to
+     * rethrow checked exceptions as unchecked RuntimeException.
+     */
+    @FunctionalInterface
+    public interface ThrowingConsumer<T> extends Consumer<T> {
+
+        @Override
+        default void accept(final T e) {
+            try {
+                throwingAccept(e);
+            } catch (Throwable ex) {
+                rethrowChecked(ex);
+            }
+        }
+
+        void throwingAccept(T e) throws Throwable;
+
+        /**
+         * Wraps a ThrowingConsumer which can throw an Exception into a regular java Consumer which does not
+         * throw anything. If the consumer throws any exception, it will be rethrown as an unchecked
+         * RuntimeException.
+         *
+         * @param consumer a throwing consumer which may throw an exception
+         * @return the throwing consumer wrapped as a regular java consumer
+         * @param <T> the type of the acceptable input
+         */
+        static <T> Consumer<T> unchecked(final ThrowingConsumer<T> consumer) {
+            return consumer;
+        }
+
+        /**
+         * Rethrow an exception as an unchecked RuntimeException, even if the Throwable is a
+         * checked Exception.
+         */
+        @SuppressWarnings("unchecked")
+        private static <E extends Throwable> void rethrowChecked(Throwable ex) throws E {
+            throw (E) ex;
+        }
+    }
 
     static Buffer copiedBuffer(String str, Charset charset) {
         return DefaultBufferAllocators.onHeapAllocator().copyOf(str, charset);

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpData.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpData.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.function.Consumer;
 
 /**
  * Extended interface for InterfaceHttpData
@@ -131,21 +132,21 @@ public interface HttpData extends InterfaceHttpData {
     byte[] get() throws IOException;
 
     /**
-     * Returns the content of the file item as a Buffer.<br>
+     * Calls the passed callback to operate on the file item as a Buffer.<br>
      * Note: this method will allocate a lot of memory, if the data is currently stored on the file system.
      *
      * <p>Buffer ownersip:</p>
+     * The ownership of the buffer passed to the callack is not transferred and remains to this HttpData interface.
      * <ul>
-     *     <li>for in memory based content, the ownership of the returned buffer is not transferred to the caller</li>
-     *     <li>for disk based content, the getBuffer() method always return a new Buffer, in this case the
-     *     ownership of the returned buffer is transferred to the caller</li>
+     *     <li> for memory based http data, the internal buffer is directly passed to the callback.</li>
+     *     <li> for disk based http data, a copy of the file content is passed to the callback and is immediately
+     *     closed once the callback returns.</li>
      * </ul>
      *
-     * @return the content of the file item as a ByteBuf
+     * @param contentCallback The file item buffer callback
      * @throws IOException
-     *
      */
-    Buffer getBuffer() throws IOException;
+    void withBuffer(Consumer<Buffer> contentCallback) throws IOException;
 
     /**
      * Returns a ChannelBuffer for the content from the current position with at
@@ -226,16 +227,20 @@ public interface HttpData extends InterfaceHttpData {
     File getFile() throws IOException;
 
     /**
-     * Return the data which is held by this {@link HttpData}.
+     * Calls the passed callback to operate on the file item as a Buffer.<br>
+     * Note: this method will allocate a lot of memory, if the data is currently stored on the file system.
      *
      * <p>Buffer ownersip:</p>
+     * The ownership of the buffer passed to the callack is not transferred and remains to this HttpData interface.
      * <ul>
-     *     <li>for in memory based content, the ownership of the returned buffer is not transferred to the caller</li>
-     *     <li>for disk based content, the content() method always return a new Buffer, in this case the
-     *     ownership of the returned buffer is transferred to the caller</li>
+     *     <li> for memory based http data, the internal buffer is directly passed to the callback.</li>
+     *     <li> for disk based http data, a copy of the file content is passed to the callback and is immediately
+     *     closed once the callback returns.</li>
      * </ul>
+     *
+     * @param contentCallback The file item buffer callback
      */
-    Buffer content();
+    void withContent(Consumer<Buffer> contentCallback);
 
     /**
      * Creates a deep copy of this {@link HttpData}.

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpData.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpData.java
@@ -16,12 +16,12 @@
 package io.netty.contrib.handler.codec.http.multipart;
 
 import io.netty5.buffer.Buffer;
+import io.netty.contrib.handler.codec.http.multipart.Helpers.ThrowingConsumer;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.util.function.Consumer;
 
 /**
  * Extended interface for InterfaceHttpData
@@ -143,10 +143,12 @@ public interface HttpData extends InterfaceHttpData {
      *     closed once the callback returns.</li>
      * </ul>
      *
-     * @param contentCallback The file item buffer callback
-     * @throws IOException
+     * @param callback The file item buffer callback
+     * @param <E> the type of the exception thrown by the callback
+     * @throws IOException if the method can't load the buffer from disk
+     * @throws E if the callback throws that exception
      */
-    void withBuffer(Consumer<Buffer> contentCallback) throws IOException;
+    <E extends Exception> void usingBuffer(ThrowingConsumer<Buffer, E> callback) throws IOException, E;
 
     /**
      * Returns a ChannelBuffer for the content from the current position with at
@@ -238,9 +240,11 @@ public interface HttpData extends InterfaceHttpData {
      *     closed once the callback returns.</li>
      * </ul>
      *
-     * @param contentCallback The file item buffer callback
+     * @param callback The file item buffer callback
+     * @param <E> the type of the exception thrown by the callback
+     * @throws E if the callback throws that exception
      */
-    void withContent(Consumer<Buffer> contentCallback);
+    <E extends Exception> void usingContent(ThrowingConsumer<Buffer, E> callback) throws E;
 
     /**
      * Creates a deep copy of this {@link HttpData}.

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -40,6 +40,7 @@ import java.util.TreeMap;
 
 import static io.netty5.util.internal.ObjectUtil.checkNotNullWithIAE;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
+import static io.netty.contrib.handler.codec.http.multipart.Helpers.ThrowingConsumer.unchecked;
 
 /**
  * This decoder will decode Body and can handle POST BODY.
@@ -539,16 +540,13 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
 
     private void setFinalBuffer(Buffer buffer) throws IOException {
         currentAttribute.addContent(buffer, true);
-        Buffer currentBuf = currentAttribute.getBuffer();
-        Buffer decodedBuf = decodeAttribute(currentBuf, charset);
-        if (decodedBuf != null) { // override content only when ByteBuf needed decoding
-            currentAttribute.setContent(decodedBuf);
-        }
+        currentAttribute.withBuffer(unchecked(attrBuffer -> {
+            Buffer decodedBuf = decodeAttribute(attrBuffer, charset);
+            if (decodedBuf != null) { // override content only when ByteBuf needed decoding
+                currentAttribute.setContent(decodedBuf);
+            }
+        }));
         addHttpData(currentAttribute);
-        if (! currentAttribute.isInMemory() && currentBuf != null && currentBuf.isAccessible()) {
-            // disked based attribute always returned an allocated buffer from getBuffer method, so we need to close
-            currentBuf.close();
-        }
         currentAttribute = null;
     }
 

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -40,7 +40,6 @@ import java.util.TreeMap;
 
 import static io.netty5.util.internal.ObjectUtil.checkNotNullWithIAE;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
-import static io.netty.contrib.handler.codec.http.multipart.Helpers.ThrowingConsumer.unchecked;
 
 /**
  * This decoder will decode Body and can handle POST BODY.
@@ -540,12 +539,12 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
 
     private void setFinalBuffer(Buffer buffer) throws IOException {
         currentAttribute.addContent(buffer, true);
-        currentAttribute.withBuffer(unchecked(attrBuffer -> {
+        currentAttribute.usingBuffer(attrBuffer -> {
             Buffer decodedBuf = decodeAttribute(attrBuffer, charset);
             if (decodedBuf != null) { // override content only when ByteBuf needed decoding
                 currentAttribute.setContent(decodedBuf);
             }
-        }));
+        });
         addHttpData(currentAttribute);
         currentAttribute = null;
     }

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/MemoryAttribute.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/MemoryAttribute.java
@@ -64,7 +64,7 @@ public class MemoryAttribute extends AbstractMemoryHttpData implements Attribute
 
     @Override
     public String getValue() {
-        return getBuffer().toString(getCharset());
+        return byteBuf.toString(getCharset());
     }
 
     @Override
@@ -130,8 +130,7 @@ public class MemoryAttribute extends AbstractMemoryHttpData implements Attribute
 
     @Override
     public Attribute copy() {
-        final Buffer content = content();
-        return replace(content != null ? content.copy() : null);
+        return replace(byteBuf != null ? byteBuf.copy() : null);
     }
 
     @Override
@@ -152,7 +151,7 @@ public class MemoryAttribute extends AbstractMemoryHttpData implements Attribute
 
     @Override
     protected Owned<AbstractHttpData> prepareSend() {
-        Send<Buffer> send = getBuffer().send();
+        Send<Buffer> send = byteBuf.send();
         return drop -> {
             Buffer received = send.receive();
             MemoryAttribute attr = new MemoryAttribute(getName());
@@ -167,6 +166,6 @@ public class MemoryAttribute extends AbstractMemoryHttpData implements Attribute
 
     @Override
     protected RuntimeException createResourceClosedException() {
-        return InternalBufferUtils.bufferIsClosed(getBuffer());
+        return InternalBufferUtils.bufferIsClosed(byteBuf);
     }
 }

--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/MemoryFileUpload.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/MemoryFileUpload.java
@@ -119,8 +119,7 @@ public class MemoryFileUpload extends AbstractMemoryHttpData implements FileUplo
 
     @Override
     public FileUpload copy() {
-        final Buffer content = content();
-        return replace(content != null ? content.copy() : content);
+        return replace(byteBuf != null ? byteBuf.copy() : byteBuf);
     }
 
     @Override
@@ -141,7 +140,7 @@ public class MemoryFileUpload extends AbstractMemoryHttpData implements FileUplo
 
     @Override
     protected Owned<AbstractHttpData> prepareSend() {
-        Send<Buffer> send = getBuffer().send();
+        Send<Buffer> send = byteBuf.send();
 
         return drop -> {
             Buffer received = send.receive();

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/AbstractMemoryHttpDataTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/AbstractMemoryHttpDataTest.java
@@ -55,11 +55,12 @@ public class AbstractMemoryHttpDataTest {
                 fos.close();
             }
             test.setContent(tmpFile);
-            Buffer buf = test.getBuffer();
-            assertEquals(buf.readerOffset(), 0);
-            assertEquals(buf.writerOffset(), bytes.length);
-            assertArrayEquals(bytes, test.get());
-            assertArrayEquals(bytes, BufferUtil.getBytes(buf));
+            test.withBuffer(buf -> {
+                assertEquals(buf.readerOffset(), 0);
+                assertEquals(buf.writerOffset(), bytes.length);
+                assertArrayEquals(bytes, test.get());
+                assertArrayEquals(bytes, BufferUtil.getBytes(buf));
+            });
         }
     }
 
@@ -103,21 +104,22 @@ public class AbstractMemoryHttpDataTest {
     @Test
     public void testSetContentFromStream() throws Exception {
         // definedSize=0
-        TestHttpData test = new TestHttpData("test", UTF_8, 0);
-        String contentStr = "foo_test";
-        Buffer buf = Helpers.copiedBuffer(contentStr.getBytes(UTF_8));
-        BufferInputStream is = new BufferInputStream(buf.send());
-        try {
-            test.setContent(is);
-            assertFalse(buf.readableBytes() > 0);
-            assertEquals(test.getString(UTF_8), contentStr);
-            buf = Helpers.copiedBuffer(contentStr.getBytes(UTF_8));
-            Buffer buf2 = test.getBuffer();
-            assertTrue(BufferUtil.equals(buf, buf.readerOffset(), buf2, buf2.readerOffset(), buf2.readableBytes()));
-            buf.close();
-            buf2.close();
-        } finally {
-            is.close();
+        try (TestHttpData test = new TestHttpData("test", UTF_8, 0)) {
+            String contentStr = "foo_test";
+            Buffer buf = Helpers.copiedBuffer(contentStr.getBytes(UTF_8));
+            BufferInputStream is = new BufferInputStream(buf.send());
+            try {
+                test.setContent(is);
+                assertFalse(buf.readableBytes() > 0);
+                assertEquals(test.getString(UTF_8), contentStr);
+                try (Buffer buf2 = Helpers.copiedBuffer(contentStr.getBytes(UTF_8))) {
+                    test.withBuffer(testBuf -> {
+                        assertTrue(BufferUtil.equals(buf2, buf2.readerOffset(), testBuf, testBuf.readerOffset(), testBuf.readableBytes()));
+                    });
+                }
+            } finally {
+                is.close();
+            }
         }
 
         Random random = new SecureRandom();
@@ -134,12 +136,12 @@ public class AbstractMemoryHttpDataTest {
                 data.setContent(new ByteArrayInputStream(bytes));
 
                 // Validate stored data.
-                try (Buffer buffer = data.getBuffer()) {
+                data.withBuffer(buffer -> {
                     assertEquals(0, buffer.readerOffset());
                     assertEquals(bytes.length, buffer.writerOffset());
                     assertArrayEquals(bytes, BufferUtil.getBytes(buffer));
                     assertArrayEquals(bytes, data.get());
-                }
+                });
             }
         }
     }

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/AbstractMemoryHttpDataTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/AbstractMemoryHttpDataTest.java
@@ -55,7 +55,7 @@ public class AbstractMemoryHttpDataTest {
                 fos.close();
             }
             test.setContent(tmpFile);
-            test.withBuffer(buf -> {
+            test.usingBuffer(buf -> {
                 assertEquals(buf.readerOffset(), 0);
                 assertEquals(buf.writerOffset(), bytes.length);
                 assertArrayEquals(bytes, test.get());
@@ -113,7 +113,7 @@ public class AbstractMemoryHttpDataTest {
                 assertFalse(buf.readableBytes() > 0);
                 assertEquals(test.getString(UTF_8), contentStr);
                 try (Buffer buf2 = Helpers.copiedBuffer(contentStr.getBytes(UTF_8))) {
-                    test.withBuffer(testBuf -> {
+                    test.usingBuffer(testBuf -> {
                         assertTrue(BufferUtil.equals(buf2, buf2.readerOffset(), testBuf, testBuf.readerOffset(), testBuf.readableBytes()));
                     });
                 }
@@ -136,7 +136,7 @@ public class AbstractMemoryHttpDataTest {
                 data.setContent(new ByteArrayInputStream(bytes));
 
                 // Validate stored data.
-                data.withBuffer(buffer -> {
+                data.usingBuffer(buffer -> {
                     assertEquals(0, buffer.readerOffset());
                     assertEquals(bytes.length, buffer.writerOffset());
                     assertArrayEquals(bytes, BufferUtil.getBytes(buffer));

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/DefaultHttpDataFactoryTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/DefaultHttpDataFactoryTest.java
@@ -87,21 +87,21 @@ public class DefaultHttpDataFactoryTest {
         file2.setContent(Helpers.copiedBuffer("file2 content", UTF_8));
 
         // Assert that they are not deleted
-        assertNotNull(attribute1.getBuffer());
-        assertNotNull(attribute2.getBuffer());
-        assertNotNull(file1.getBuffer());
-        assertNotNull(file2.getBuffer());
+        attribute1.withBuffer(buf -> assertNotNull(buf));
+        attribute2.withBuffer(buf -> assertNotNull(buf));
+        file1.withBuffer(buf -> assertNotNull(buf));
+        file2.withBuffer(buf -> assertNotNull(buf));
 
         // Clean up by req1
         factory.cleanRequestHttpData(req1);
 
         // Assert that data belonging to req1 has been cleaned up
-        assertNull(attribute1.getBuffer());
-        assertNull(file1.getBuffer());
+        attribute1.withBuffer(buf -> assertNull(buf));
+        file1.withBuffer(buf -> assertNull(buf));
 
         // But not req2
-        assertNotNull(attribute2.getBuffer());
-        assertNotNull(file2.getBuffer());
+        attribute2.withBuffer(buf -> assertNotNull(buf));
+        file2.withBuffer(buf -> assertNotNull(buf));
     }
 
     @Test
@@ -134,12 +134,12 @@ public class DefaultHttpDataFactoryTest {
         factory.cleanRequestHttpData(req1);
 
         // Assert that attribute1 and file1 have been cleaned up
-        assertNull(attribute1.getBuffer());
-        assertNull(file1.getBuffer());
+        attribute1.withBuffer(buf -> assertNull(buf));
+        file1.withBuffer(buf -> assertNull(buf));
 
         // But not attribute2 and file2
-        assertNotNull(attribute2.getBuffer());
-        assertNotNull(file2.getBuffer());
+        attribute2.withBuffer(buf -> assertNotNull(buf));
+        file2.withBuffer(buf -> assertNotNull(buf));
 
         // Cleanup attribute2 and file2 manually to avoid memory leak, not via factory
         attribute2.close();

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/DefaultHttpDataFactoryTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/DefaultHttpDataFactoryTest.java
@@ -87,21 +87,21 @@ public class DefaultHttpDataFactoryTest {
         file2.setContent(Helpers.copiedBuffer("file2 content", UTF_8));
 
         // Assert that they are not deleted
-        attribute1.withBuffer(buf -> assertNotNull(buf));
-        attribute2.withBuffer(buf -> assertNotNull(buf));
-        file1.withBuffer(buf -> assertNotNull(buf));
-        file2.withBuffer(buf -> assertNotNull(buf));
+        attribute1.usingBuffer(buf -> assertNotNull(buf));
+        attribute2.usingBuffer(buf -> assertNotNull(buf));
+        file1.usingBuffer(buf -> assertNotNull(buf));
+        file2.usingBuffer(buf -> assertNotNull(buf));
 
         // Clean up by req1
         factory.cleanRequestHttpData(req1);
 
         // Assert that data belonging to req1 has been cleaned up
-        attribute1.withBuffer(buf -> assertNull(buf));
-        file1.withBuffer(buf -> assertNull(buf));
+        attribute1.usingBuffer(buf -> assertNull(buf));
+        file1.usingBuffer(buf -> assertNull(buf));
 
         // But not req2
-        attribute2.withBuffer(buf -> assertNotNull(buf));
-        file2.withBuffer(buf -> assertNotNull(buf));
+        attribute2.usingBuffer(buf -> assertNotNull(buf));
+        file2.usingBuffer(buf -> assertNotNull(buf));
     }
 
     @Test
@@ -134,12 +134,12 @@ public class DefaultHttpDataFactoryTest {
         factory.cleanRequestHttpData(req1);
 
         // Assert that attribute1 and file1 have been cleaned up
-        attribute1.withBuffer(buf -> assertNull(buf));
-        file1.withBuffer(buf -> assertNull(buf));
+        attribute1.usingBuffer(buf -> assertNull(buf));
+        file1.usingBuffer(buf -> assertNull(buf));
 
         // But not attribute2 and file2
-        attribute2.withBuffer(buf -> assertNotNull(buf));
-        file2.withBuffer(buf -> assertNotNull(buf));
+        attribute2.usingBuffer(buf -> assertNotNull(buf));
+        file2.usingBuffer(buf -> assertNotNull(buf));
 
         // Cleanup attribute2 and file2 manually to avoid memory leak, not via factory
         attribute2.close();

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/DiskFileUploadTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/DiskFileUploadTest.java
@@ -33,7 +33,6 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static io.netty.contrib.handler.codec.http.multipart.Helpers.ThrowingConsumer.unchecked;
 
 @ExtendWith(GCExtension.class)
 public class DiskFileUploadTest {
@@ -196,7 +195,7 @@ public class DiskFileUploadTest {
                 buffer = Helpers.copiedBuffer(bytes);
             }
             f1.addContent(buffer, true);
-            f1.withBuffer(buf -> {
+            f1.usingBuffer(buf -> {
                 assertEquals(buf.readerOffset(), 0);
                 assertEquals(buf.writerOffset(), bytes.length);
                 assertArrayEquals(bytes, BufferUtil.getBytes(buf));
@@ -292,13 +291,7 @@ public class DiskFileUploadTest {
                 file = f1Copy.getFile();
                 assertEquals((long) bytes.length, file.length());
                 assertArrayEquals(bytes, doReadFile(file, bytes.length));
-                f1.withBuffer(unchecked(f1Buf -> {
-                    f1Copy.withBuffer(f1CopyBuf -> {
-                        assertEquals(f1Buf, f1CopyBuf);
-                        // f1CopyBuf will be closed when this lambda returns
-                    });
-                    // f1Buf will be closed when this lambda returns
-                }));
+                f1.usingBuffer(f1Buf -> f1Copy.usingBuffer(f1CopyBuf -> assertEquals(f1Buf, f1CopyBuf)));
             }
         }
     }

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/DiskFileUploadTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/DiskFileUploadTest.java
@@ -33,6 +33,7 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static io.netty.contrib.handler.codec.http.multipart.Helpers.ThrowingConsumer.unchecked;
 
 @ExtendWith(GCExtension.class)
 public class DiskFileUploadTest {
@@ -195,11 +196,12 @@ public class DiskFileUploadTest {
                 buffer = Helpers.copiedBuffer(bytes);
             }
             f1.addContent(buffer, true);
-            Buffer buf = f1.getBuffer();
-            assertEquals(buf.readerOffset(), 0);
-            assertEquals(buf.writerOffset(), bytes.length);
-            assertArrayEquals(bytes, BufferUtil.getBytes(buf));
-            buf.close(); // disk file upload always return an allocated buffer from its getBuffer() method
+            f1.withBuffer(buf -> {
+                assertEquals(buf.readerOffset(), 0);
+                assertEquals(buf.writerOffset(), bytes.length);
+                assertArrayEquals(bytes, BufferUtil.getBytes(buf));
+                // buffer will be closed when this lambda returns
+            });
         }
     }
 
@@ -290,11 +292,13 @@ public class DiskFileUploadTest {
                 file = f1Copy.getFile();
                 assertEquals((long) bytes.length, file.length());
                 assertArrayEquals(bytes, doReadFile(file, bytes.length));
-
-                try (Buffer f1Buf = f1.getBuffer();
-                    Buffer f1CopyBuf = f1Copy.getBuffer()) {
-                    assertEquals(f1Buf, f1CopyBuf);
-                }
+                f1.withBuffer(unchecked(f1Buf -> {
+                    f1Copy.withBuffer(f1CopyBuf -> {
+                        assertEquals(f1Buf, f1CopyBuf);
+                        // f1CopyBuf will be closed when this lambda returns
+                    });
+                    // f1Buf will be closed when this lambda returns
+                }));
             }
         }
     }

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpDataTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpDataTest.java
@@ -76,7 +76,7 @@ class HttpDataTest {
         httpData.addContent(DefaultBufferAllocators.preferredAllocator().allocate(0), false);
 
         try (HttpData copy = httpData.copy()) {
-            httpData.withContent(content -> copy.withContent(copyContent -> assertThat(content).isEqualTo(copyContent)));
+            httpData.usingContent(content -> copy.usingContent(copyContent -> assertThat(content).isEqualTo(copyContent)));
         }
     }
 
@@ -84,7 +84,7 @@ class HttpDataTest {
     void testCompletedFlagPreservedAfterRetainDuplicate(HttpData httpData) throws IOException {
         httpData.addContent(Helpers.copiedBuffer("foo".getBytes(StandardCharsets.UTF_8)), false);
         assertThat(httpData.isCompleted()).isFalse();
-        httpData.withContent(content -> {
+        httpData.usingContent(content -> {
             try (HttpData duplicate = httpData.replace(content.split())) {
                 assertThat(duplicate.isCompleted()).isFalse();
             }
@@ -92,7 +92,7 @@ class HttpDataTest {
 
         httpData.addContent(Helpers.copiedBuffer("bar".getBytes(StandardCharsets.UTF_8)), true);
         assertThat(httpData.isCompleted()).isTrue();
-        httpData.withContent(content -> {
+        httpData.usingContent(content -> {
             try (HttpData duplicate = httpData.replace(content.split())) {
                 assertThat(duplicate.isCompleted()).isTrue();
             }

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
@@ -128,7 +128,7 @@ public class HttpPostMultiPartRequestDecoderTest {
         Buffer content = Helpers.copiedBuffer(body);
         httpContent = new DefaultHttpContent(content);
         decoder.offer(httpContent); // Ouf of range before here
-        ((HttpData) decoder.currentPartialHttpData()).withBuffer(b -> assertNotNull(b));
+        ((HttpData) decoder.currentPartialHttpData()).usingBuffer(b -> assertNotNull(b));
         httpContent.close();
         content = Helpers.copiedBuffer(bsuffix2);
         httpContent = new DefaultHttpContent(content);
@@ -172,7 +172,7 @@ public class HttpPostMultiPartRequestDecoderTest {
         Buffer buf = Helpers.copiedBuffer(prefix.getBytes(StandardCharsets.UTF_8));
         DefaultHttpContent httpContent = new DefaultHttpContent(buf);
         decoder.offer(httpContent);
-        ((HttpData) decoder.currentPartialHttpData()).withBuffer(partial -> {
+        ((HttpData) decoder.currentPartialHttpData()).usingBuffer(partial -> {
             assertNotNull(partial);
             partialBuffers.add(partial);
         });
@@ -187,7 +187,7 @@ public class HttpPostMultiPartRequestDecoderTest {
             Buffer content = Helpers.copiedBuffer(body, 0, bytesPerChunk);
             httpContent = new DefaultHttpContent(content);
             decoder.offer(httpContent); // **OutOfMemory previously here**
-            ((HttpData) decoder.currentPartialHttpData()).withBuffer(partial -> {
+            ((HttpData) decoder.currentPartialHttpData()).usingBuffer(partial -> {
                 assertNotNull(partial);
                 partialBuffers.add(partial);
             });
@@ -215,7 +215,7 @@ public class HttpPostMultiPartRequestDecoderTest {
         Buffer content2 = Helpers.copiedBuffer(previousLastbody, 0, previousLastbody.length);
         httpContent = new DefaultHttpContent(content2);
         decoder.offer(httpContent);
-        ((HttpData) decoder.currentPartialHttpData()).withBuffer(partial -> {
+        ((HttpData) decoder.currentPartialHttpData()).usingBuffer(partial -> {
             assertNotNull(partial);
             partialBuffers.add(partial);
         });
@@ -223,7 +223,7 @@ public class HttpPostMultiPartRequestDecoderTest {
         content2 = Helpers.copiedBuffer(lastbody, 0, lastbody.length);
         httpContent = new DefaultHttpContent(content2);
         decoder.offer(httpContent);
-        ((HttpData) decoder.currentPartialHttpData()).withBuffer(partial -> {
+        ((HttpData) decoder.currentPartialHttpData()).usingBuffer(partial -> {
             assertNotNull(partial);
             partialBuffers.add(partial);
         });
@@ -241,7 +241,7 @@ public class HttpPostMultiPartRequestDecoderTest {
         assertEquals(inMemory, data.isInMemory());
         if (data.isInMemory()) {
             // To be done only if not inMemory: assertEquals(data.get().length, fileSize);
-            data.withBuffer(b -> assertFalse(b.capacity() < 1024 * 1024,
+            data.usingBuffer(b -> assertFalse(b.capacity() < 1024 * 1024,
                     "Capacity should be higher than 1M"));
         }
         assertTrue(decoder.getCurrentAllocatedCapacity() < 1024 * 1024,
@@ -425,7 +425,7 @@ public class HttpPostMultiPartRequestDecoderTest {
         Buffer buf = Helpers.copiedBuffer(prefix.getBytes(StandardCharsets.UTF_8));
         DefaultHttpContent httpContent = new DefaultHttpContent(buf);
         decoder.offer(httpContent);
-        ((HttpData) decoder.currentPartialHttpData()).withBuffer(partial -> {
+        ((HttpData) decoder.currentPartialHttpData()).usingBuffer(partial -> {
             assertNotNull(partial);
             partialBuffers.add(partial);
         });
@@ -441,7 +441,7 @@ public class HttpPostMultiPartRequestDecoderTest {
             httpContent = new DefaultHttpContent(content);
             decoder.offer(httpContent);
             // **OutOfMemory previously here**
-            ((HttpData) decoder.currentPartialHttpData()).withBuffer(partial -> {
+            ((HttpData) decoder.currentPartialHttpData()).usingBuffer(partial -> {
                 assertNotNull(partial);
                 partialBuffers.add(partial);
             });
@@ -478,7 +478,7 @@ public class HttpPostMultiPartRequestDecoderTest {
         assertEquals(inMemory, data.isInMemory());
         if (data.isInMemory()) {
             // To be done only if not inMemory: assertEquals(data.get().length, fileSize);
-            data.withBuffer(b -> assertFalse(b.capacity() < fileSize,
+            data.usingBuffer(b -> assertFalse(b.capacity() < fileSize,
                         "Capacity should be at least file size"));
         }
         assertTrue(decoder.getCurrentAllocatedCapacity() < fileSize,

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
@@ -128,7 +128,7 @@ public class HttpPostMultiPartRequestDecoderTest {
         Buffer content = Helpers.copiedBuffer(body);
         httpContent = new DefaultHttpContent(content);
         decoder.offer(httpContent); // Ouf of range before here
-        assertNotNull(((HttpData) decoder.currentPartialHttpData()).getBuffer());
+        ((HttpData) decoder.currentPartialHttpData()).withBuffer(b -> assertNotNull(b));
         httpContent.close();
         content = Helpers.copiedBuffer(bsuffix2);
         httpContent = new DefaultHttpContent(content);
@@ -172,9 +172,10 @@ public class HttpPostMultiPartRequestDecoderTest {
         Buffer buf = Helpers.copiedBuffer(prefix.getBytes(StandardCharsets.UTF_8));
         DefaultHttpContent httpContent = new DefaultHttpContent(buf);
         decoder.offer(httpContent);
-        Buffer partial = ((HttpData) decoder.currentPartialHttpData()).getBuffer();
-        assertNotNull(partial);
-        partialBuffers.add(partial);
+        ((HttpData) decoder.currentPartialHttpData()).withBuffer(partial -> {
+            assertNotNull(partial);
+            partialBuffers.add(partial);
+        });
         httpContent.close();
 
         byte[] body = new byte[bytesPerChunk];
@@ -186,9 +187,10 @@ public class HttpPostMultiPartRequestDecoderTest {
             Buffer content = Helpers.copiedBuffer(body, 0, bytesPerChunk);
             httpContent = new DefaultHttpContent(content);
             decoder.offer(httpContent); // **OutOfMemory previously here**
-            partial = ((HttpData) decoder.currentPartialHttpData()).getBuffer();
-            assertNotNull(partial);
-            partialBuffers.add(partial);
+            ((HttpData) decoder.currentPartialHttpData()).withBuffer(partial -> {
+                assertNotNull(partial);
+                partialBuffers.add(partial);
+            });
             httpContent.close();
         }
 
@@ -213,16 +215,18 @@ public class HttpPostMultiPartRequestDecoderTest {
         Buffer content2 = Helpers.copiedBuffer(previousLastbody, 0, previousLastbody.length);
         httpContent = new DefaultHttpContent(content2);
         decoder.offer(httpContent);
-        partial = ((HttpData) decoder.currentPartialHttpData()).getBuffer();
-        assertNotNull(partial);
-        partialBuffers.add(partial);
+        ((HttpData) decoder.currentPartialHttpData()).withBuffer(partial -> {
+            assertNotNull(partial);
+            partialBuffers.add(partial);
+        });
         httpContent.close();
         content2 = Helpers.copiedBuffer(lastbody, 0, lastbody.length);
         httpContent = new DefaultHttpContent(content2);
         decoder.offer(httpContent);
-        partial = ((HttpData) decoder.currentPartialHttpData()).getBuffer();
-        assertNotNull(partial);
-        partialBuffers.add(partial);
+        ((HttpData) decoder.currentPartialHttpData()).withBuffer(partial -> {
+            assertNotNull(partial);
+            partialBuffers.add(partial);
+        });
         httpContent.close();
         content2 = Helpers.copiedBuffer(suffix2.getBytes(StandardCharsets.UTF_8));
         httpContent = new DefaultHttpContent(content2);
@@ -237,8 +241,8 @@ public class HttpPostMultiPartRequestDecoderTest {
         assertEquals(inMemory, data.isInMemory());
         if (data.isInMemory()) {
             // To be done only if not inMemory: assertEquals(data.get().length, fileSize);
-            assertFalse(data.getBuffer().capacity() < 1024 * 1024,
-                    "Capacity should be higher than 1M");
+            data.withBuffer(b -> assertFalse(b.capacity() < 1024 * 1024,
+                    "Capacity should be higher than 1M"));
         }
         assertTrue(decoder.getCurrentAllocatedCapacity() < 1024 * 1024,
                 "Capacity should be less than 1M");
@@ -421,9 +425,10 @@ public class HttpPostMultiPartRequestDecoderTest {
         Buffer buf = Helpers.copiedBuffer(prefix.getBytes(StandardCharsets.UTF_8));
         DefaultHttpContent httpContent = new DefaultHttpContent(buf);
         decoder.offer(httpContent);
-        Buffer partial = ((HttpData) decoder.currentPartialHttpData()).getBuffer();
-        assertNotNull(partial);
-        partialBuffers.add(partial);
+        ((HttpData) decoder.currentPartialHttpData()).withBuffer(partial -> {
+            assertNotNull(partial);
+            partialBuffers.add(partial);
+        });
         httpContent.close();
 
         byte[] body = new byte[bytesPerChunk];
@@ -434,10 +439,12 @@ public class HttpPostMultiPartRequestDecoderTest {
         for (int i = 0; i < nbChunks; i++) {
             Buffer content = Helpers.copiedBuffer(body, 0, bytesPerChunk);
             httpContent = new DefaultHttpContent(content);
-            decoder.offer(httpContent); // **OutOfMemory previously here**
-            partial = ((HttpData) decoder.currentPartialHttpData()).getBuffer();
-            assertNotNull(partial);
-            partialBuffers.add(partial);
+            decoder.offer(httpContent);
+            // **OutOfMemory previously here**
+            ((HttpData) decoder.currentPartialHttpData()).withBuffer(partial -> {
+                assertNotNull(partial);
+                partialBuffers.add(partial);
+            });
             httpContent.close();
         }
         // Last -2 body = content + CR but no delimiter
@@ -471,8 +478,8 @@ public class HttpPostMultiPartRequestDecoderTest {
         assertEquals(inMemory, data.isInMemory());
         if (data.isInMemory()) {
             // To be done only if not inMemory: assertEquals(data.get().length, fileSize);
-            assertFalse(data.getBuffer().capacity() < fileSize,
-                        "Capacity should be at least file size");
+            data.withBuffer(b -> assertFalse(b.capacity() < fileSize,
+                        "Capacity should be at least file size"));
         }
         assertTrue(decoder.getCurrentAllocatedCapacity() < fileSize,
                    "Capacity should be less than 1M");

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -772,10 +772,10 @@ public class HttpPostRequestDecoderTest {
         assertEquals(2, decoder.getBodyHttpDatas().size());
 
         Attribute attrMsg = (Attribute) decoder.getBodyHttpData("msg");
-        attrMsg.withBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
+        attrMsg.usingBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
         assertEquals("test message", attrMsg.getValue());
         Attribute attrMsgId = (Attribute) decoder.getBodyHttpData("msg_id");
-        attrMsgId.withBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
+        attrMsgId.usingBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
         assertEquals("15200", attrMsgId.getValue());
 
         decoder.destroy();
@@ -891,23 +891,23 @@ public class HttpPostRequestDecoderTest {
         assertEquals(5, decoder.getBodyHttpDatas().size());
 
         Attribute attr = (Attribute) decoder.getBodyHttpData("foo");
-        attr.withBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
+        attr.usingBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
         assertEquals("bar", attr.getValue());
 
         attr = (Attribute) decoder.getBodyHttpData("a");
-        attr.withBuffer(attrBuf ->assertTrue(attrBuf.isDirect()));
+        attr.usingBuffer(attrBuf ->assertTrue(attrBuf.isDirect()));
         assertEquals("b", attr.getValue());
 
         attr = (Attribute) decoder.getBodyHttpData("empty");
-        attr.withBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
+        attr.usingBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
         assertEquals("", attr.getValue());
 
         attr = (Attribute) decoder.getBodyHttpData("city");
-        attr.withBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
+        attr.usingBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
         assertEquals("<\"new\" york city>", attr.getValue());
 
         attr = (Attribute) decoder.getBodyHttpData("other_city");
-        attr.withBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
+        attr.usingBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
         assertEquals("los angeles", attr.getValue());
 
         decoder.destroy();

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -772,10 +772,10 @@ public class HttpPostRequestDecoderTest {
         assertEquals(2, decoder.getBodyHttpDatas().size());
 
         Attribute attrMsg = (Attribute) decoder.getBodyHttpData("msg");
-        assertTrue(attrMsg.getBuffer().isDirect());
+        attrMsg.withBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
         assertEquals("test message", attrMsg.getValue());
         Attribute attrMsgId = (Attribute) decoder.getBodyHttpData("msg_id");
-        assertTrue(attrMsgId.getBuffer().isDirect());
+        attrMsgId.withBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
         assertEquals("15200", attrMsgId.getValue());
 
         decoder.destroy();
@@ -891,23 +891,23 @@ public class HttpPostRequestDecoderTest {
         assertEquals(5, decoder.getBodyHttpDatas().size());
 
         Attribute attr = (Attribute) decoder.getBodyHttpData("foo");
-        assertTrue(attr.getBuffer().isDirect());
+        attr.withBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
         assertEquals("bar", attr.getValue());
 
         attr = (Attribute) decoder.getBodyHttpData("a");
-        assertTrue(attr.getBuffer().isDirect());
+        attr.withBuffer(attrBuf ->assertTrue(attrBuf.isDirect()));
         assertEquals("b", attr.getValue());
 
         attr = (Attribute) decoder.getBodyHttpData("empty");
-        assertTrue(attr.getBuffer().isDirect());
+        attr.withBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
         assertEquals("", attr.getValue());
 
         attr = (Attribute) decoder.getBodyHttpData("city");
-        assertTrue(attr.getBuffer().isDirect());
+        attr.withBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
         assertEquals("<\"new\" york city>", attr.getValue());
 
         attr = (Attribute) decoder.getBodyHttpData("other_city");
-        assertTrue(attr.getBuffer().isDirect());
+        attr.withBuffer(attrBuf -> assertTrue(attrBuf.isDirect()));
         assertEquals("los angeles", attr.getValue());
 
         decoder.destroy();

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestEncoderTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestEncoderTest.java
@@ -375,7 +375,8 @@ public class HttpPostRequestEncoderTest {
             if (data instanceof InternalAttribute) {
                 buffers[i] = ((InternalAttribute) data).toBuffer();
             } else if (data instanceof HttpData) {
-                buffers[i] = ((HttpData) data).getBuffer();
+                int index = i;
+                ((HttpData) data).withBuffer(buf -> buffers[index] = buf.split());
             }
         }
 

--- a/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestEncoderTest.java
+++ b/codec-multipart/src/test/java/io/netty/contrib/handler/codec/http/multipart/HttpPostRequestEncoderTest.java
@@ -376,7 +376,7 @@ public class HttpPostRequestEncoderTest {
                 buffers[i] = ((InternalAttribute) data).toBuffer();
             } else if (data instanceof HttpData) {
                 int index = i;
-                ((HttpData) data).withBuffer(buf -> buffers[index] = buf.split());
+                ((HttpData) data).usingBuffer(buf -> buffers[index] = buf.split());
             }
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
   </developers>
 
   <properties>
-    <netty.version>5.0.0.Alpha5-SNAPSHOT</netty.version>
+    <netty.version>5.0.0.Alpha5</netty.version>
     <netty.build.version>30</netty.build.version>
     <project.scm.id>github</project.scm.id>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

Currently, the buffer ownership of the buffers returned by the _HttpData_ _getBuffer/content_ methods depends on the nature of the HttpData:

- for disk based http data, a **copy** is returned by the _getBuffer()/content()_ methods; so the user is getting the buffer ownership and is assumed to **close** the returned buffer.
- but for memory based http data , the **internal** buffer is returned by the _getBuffer()/content()_ methods; so the user don't have to close the returned buffer, because it will be closed when the http data object will be closed. However, the user can still close the buffer, in this case it won't be closed a second time when the http data object is closed.

Example of a scenario which may be confusing: the [HttpPostStandardRequestDecoder. setFinalBuffer](https://github.com/netty-contrib/codec-multipart/blob/main/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java#L540-L553) method is used to append the content of the passed buffer parameter into the current _Attribute_; then once appended, the current _Attribute_ whole content is retrieved using _currentAttribute.getBuffer()_; then it is decoded;  and then the current _Attribute_ is replaced by the decoded buffer.

Now, what is confusing is that we need to close the buffer returned by the [currentAttribute.getBuffer()](https://github.com/netty-contrib/codec-multipart/blob/main/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java#L542) method at the end of the method [here](https://github.com/netty-contrib/codec-multipart/blob/main/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java#L548-L551), but only if the type of the Attribute is disk based (not memory based).

Modifications:

This PR proposes to eliminate the difference between disk based vs memory based attribute, by replacing the _HttpData.getBuffer()_ method with a _withBuffer< Consumer< Buffer>>_ callback. So the ownership is left to the HttpData and is not transferred to the caller, and when the callback returns, then the passed buffer will be closed in case the HttpData is disk based.

The code from [HttpPostStandardRequestDecoder. setFinalBuffer](https://github.com/netty-contrib/codec-multipart/blob/main/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java#L540-L553) then can be simplified like this:

```
    private void setFinalBuffer(Buffer buffer) throws IOException {
        currentAttribute.addContent(buffer, true);
        currentAttribute.withBuffer(attrBuffer -> {
            Buffer decodedBuf = decodeAttribute(attrBuffer, charset);
            if (decodedBuf != null) { // override content only when ByteBuf needed decoding
                currentAttribute.setContent(decodedBuf);
            }
        });
        addHttpData(currentAttribute);
        currentAttribute = null;
    }
```

Now, let's see a more specific caveat/use case: using a Consumer<Buffer> callback may not be practical in case the callback can throw a checked exception. And this is the case in the above example, because the _currentAttribute.setContent(decodedBuf)_ throws an IOException. In this case a _ThrowingConsumer_ helper class has been introduced in the _Helpers_ class which allows to wrap a "_throwing consumer_" into a regular consumer using **_ThrowingConsumer.unchecked_** method. 
Then any checked exception can be re-thrown transparently, without having to do some boring try/catch in the Consumer lambda. So for this particular use case, the above code can then becomes the following (pay attention to the **unchecked** method which can wrap the throwing consumer into a regular consumer):

```
import static io.netty.contrib.handler.codec.http.multipart.Helpers.ThrowingConsumer.unchecked;

    private void setFinalBuffer(Buffer buffer) throws IOException {
        currentAttribute.addContent(buffer, true);
        currentAttribute.withBuffer(unchecked(attrBuffer -> {
            Buffer decodedBuf = decodeAttribute(attrBuffer, charset);
            if (decodedBuf != null) { // override content only when ByteBuf needed decoding
                currentAttribute.setContent(decodedBuf);
            }
        }));
        addHttpData(currentAttribute);
        currentAttribute = null;
    }

```

Likewise, the HttpData.content() method has been replaced by HttpData.withContent(Consumer<Buffer>) method.

side note: I modified the pom.xml in order to use Netty 5.0.0-Alpha5, but the target is to release the MP codec compiled with 5.0.0-Alpha5

Results:

the contract of the withBuffer/withContent methods is clearer, and the user knows that it does not acquire ownership for the buffer passed as parameter. And if the user wants to obtain the ownership, he can then call the split/copy or send method of the buffer passed to the withBuffer/withContent callbacks.