### PR TITLE
Use Netty5 Alpha6-SNAPSHOT in order to avoid slf4j conflicts.

### DIFF
--- a/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-multipart/src/main/java/io/netty/contrib/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -22,8 +22,8 @@ import io.netty5.handler.codec.http.HttpConstants;
 import io.netty5.util.internal.EmptyArrays;
 import io.netty5.util.internal.ObjectUtil;
 import io.netty5.util.internal.PlatformDependent;
-import io.netty5.util.internal.logging.InternalLogger;
-import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import io.netty.contrib.handler.codec.http.multipart.Helpers.ThrowingConsumer;
 
 import java.io.File;
@@ -40,7 +40,7 @@ import java.nio.file.Files;
  */
 public abstract class AbstractDiskHttpData extends AbstractHttpData {
 
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractDiskHttpData.class);
+    private static final Logger logger = LoggerFactory.getLogger(AbstractDiskHttpData.class);
 
     private File file;
     private boolean isRenamed;

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
   </developers>
 
   <properties>
-    <netty.version>5.0.0.Alpha5</netty.version>
+    <netty.version>5.0.0.Alpha6-SNAPSHOT</netty.version>
     <netty.build.version>31</netty.build.version>
     <project.scm.id>github</project.scm.id>
     <release.gpg.keyname />
@@ -136,6 +136,11 @@
           <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 -->
           <trimStackTrace>false</trimStackTrace>
           <argLine>${test.argLine}</argLine>
+          <systemPropertyVariables>
+            <!-- Used by ChannelHandlerMetadataUtil to create the recommended directory layout for native-image metadata -->
+            <nativeImage.handlerMetadataGroupId>${project.groupId}</nativeImage.handlerMetadataGroupId>
+            <nativeimage.handlerMetadataArtifactId>${project.artifactId}</nativeimage.handlerMetadataArtifactId>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Motivation:

This project is currently depending on Netty 5.0.0-Alpha5.
Let's depend on Netty Alpha6-SNAPSHOT, this seems to avoid dependency conflicts while adapting ReactorNetty to latest Netty Alpha6-SNAPSHOT.

Modification:

Modified the pom.xml in order to depend on 5.0.0.Alpha6-SNAPSHOT instead of 5.0.0.Alpha5
Use SLF4J API instead of InternalLogger.

Result:

This allows to avoid some dependency conflicts while adapting ReactorNetty to the latest Netty Alpha6-SNAPSHOT