### PR TITLE
Adapt to netty5 HttpCookiePair API changes

### DIFF
--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/http/multipart/HttpUploadServerHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/http/multipart/HttpUploadServerHandler.java
@@ -115,7 +115,7 @@ public class HttpUploadServerHandler extends SimpleChannelInboundHandler<HttpObj
 
             // new getMethod
             for (HttpCookiePair cookie : request.headers().getCookies()) {
-                responseContent.append("COOKIE: " + cookie.encoded() + "\r\n");
+                responseContent.append("COOKIE: " + cookie.encodedCookie() + "\r\n");
             }
 
             responseContent.append("\r\n\r\n");


### PR DESCRIPTION
Motivation:

We need to adapt to the following netty5 PR, which introduces an API change regarding HttpCookiePair:

https://github.com/netty/netty/pull/13516

Modifications:

the HttpUploadServerHandler in the example needs to be updated in order to parse the request Cookie header using `cookie.encodedCookie()` instead of `cookie.encoded()`

Results:

the codec-multipart project can now be built using latest netty 5.0.0.Alpha6-SNAPSHOT