### PR TITLE
Attempt to re-enable CI checks

### DIFF
--- a/.github/workflows/ci-scheduled-build.yml
+++ b/.github/workflows/ci-scheduled-build.yml
@@ -13,14 +13,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 # ----------------------------------------------------------------------------
-name: Build
+name: Scheduled Build
 
 on:
-  push:
-    branches: ["main"]
-  pull_request:
-    branches: ["main"]
-  workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
+  schedule:
+    - cron: '30 8 * * 1'  # At 08:30 on Monday, every Monday.
 
 jobs:
   Build:


### PR DESCRIPTION
Motivation:

This project has not been updated for more than 60 days, and apparently scheduled workflows are disabled after such period of inactivity. And it seems to also disable the CI PR checks, because currently, the ci-build.yml is both scheduled and triggered.

Modification:

Remove the scheduled cron from the current ci-build.yml, and create a new ci-scheduled-build.yml that is only scheduling builds.

Results:

Hopefully this will at least re-enable PR CI checks.