### PR TITLE
Reject multipart parts missing required Content-Disposition 'name'

### DIFF
--- a/multipart-core/src/main/java/io/netty/contrib/multipart/DecoderQuirk.java
+++ b/multipart-core/src/main/java/io/netty/contrib/multipart/DecoderQuirk.java
@@ -96,8 +96,8 @@ public enum DecoderQuirk {
      * {@code Content-Disposition} header is missing the required {@code name} parameter, instead of throwing a
      * descriptive {@code ErrorDataDecoderException} that names the missing parameter.
      * <p>
-     * The legacy decoder dereferenced the {@code name} attribute without validating its presence, so callers observed
-     * the opaque NPE message. This quirk preserves that behavior for applications that depend on it.
+     * This quirk replicates a bug where the legacy decoder dereferenced the {@code name} attribute without validating
+     * its presence, so callers observed an opaque NPE message instead of a clear validation error.
      */
     NPE_ON_MISSING_CONTENT_DISPOSITION_NAME,
 

--- a/multipart-core/src/main/java/io/netty/contrib/multipart/DecoderQuirk.java
+++ b/multipart-core/src/main/java/io/netty/contrib/multipart/DecoderQuirk.java
@@ -91,6 +91,16 @@ public enum DecoderQuirk {
      */
     DISABLE_EARLY_MIXED_END,
 
+    /**
+     * Surface a {@link NullPointerException} (wrapped in an {@code ErrorDataDecoderException}) when a multipart part's
+     * {@code Content-Disposition} header is missing the required {@code name} parameter, instead of throwing a
+     * descriptive {@code ErrorDataDecoderException} that names the missing parameter.
+     * <p>
+     * The legacy decoder dereferenced the {@code name} attribute without validating its presence, so callers observed
+     * the opaque NPE message. This quirk preserves that behavior for applications that depend on it.
+     */
+    NPE_ON_MISSING_CONTENT_DISPOSITION_NAME,
+
     // URL ENCODED
 
     /**

--- a/multipart-vintage/src/main/java/io/netty/contrib/multipart/vintage/HttpPostMultipartRequestDecoder.java
+++ b/multipart-vintage/src/main/java/io/netty/contrib/multipart/vintage/HttpPostMultipartRequestDecoder.java
@@ -541,6 +541,11 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
             }
         }
         Attribute nameAttribute = currentFieldAttributes.get(HttpHeaderValues.NAME);
+        if (nameAttribute == null
+                && !decoder.hasQuirk(DecoderQuirk.NPE_ON_MISSING_CONTENT_DISPOSITION_NAME)) {
+            throw new ErrorDataDecoderException(
+                    "Content-Disposition is missing required 'name' parameter");
+        }
         Attribute lengthAttribute = currentFieldAttributes
                 .get(HttpHeaderNames.CONTENT_LENGTH);
         long size;
@@ -774,6 +779,11 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
         }
         Attribute filenameAttribute = currentFieldAttributes.get(HttpHeaderValues.FILENAME);
         Attribute nameAttribute = currentFieldAttributes.get(HttpHeaderValues.NAME);
+        if (nameAttribute == null
+                && !decoder.hasQuirk(DecoderQuirk.NPE_ON_MISSING_CONTENT_DISPOSITION_NAME)) {
+            throw new ErrorDataDecoderException(
+                    "Content-Disposition is missing required 'name' parameter");
+        }
         Attribute contentTypeAttribute = currentFieldAttributes.get(HttpHeaderNames.CONTENT_TYPE);
         Attribute lengthAttribute = currentFieldAttributes.get(HttpHeaderNames.CONTENT_LENGTH);
         long size;

--- a/multipart-vintage/src/test/java/io/netty/contrib/multipart/vintage/HttpPostMultiPartRequestDecoderTest.java
+++ b/multipart-vintage/src/test/java/io/netty/contrib/multipart/vintage/HttpPostMultiPartRequestDecoderTest.java
@@ -592,4 +592,59 @@ public class HttpPostMultiPartRequestDecoderTest {
 
         commonTestFileDelimiterLFLastChunk(factory, false);
     }
+
+    @Test
+    public void testFieldWithoutNameAttributeThrowsErrorDataDecoderException() {
+        String boundary = "861fbeab-cd20-470c-9609-d40a0f704466";
+        String content = "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data\r\n" +
+                "\r\n" +
+                "fieldValue\r\n" +
+                "--" + boundary + "--\r\n";
+
+        FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload",
+                Unpooled.copiedBuffer(content, CharsetUtil.US_ASCII));
+        req.headers().set(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
+        req.headers().set(HttpHeaderNames.CONTENT_LENGTH, content.length());
+
+        try {
+            HttpPostMultipartRequestDecoder decoder = this.builder().buildMultipart(req);
+            decoder.getBodyHttpDatas();
+            fail("Was expecting an ErrorDataDecoderException");
+        } catch (HttpPostRequestDecoder.ErrorDataDecoderException expected) {
+            assertNotNull(expected.getMessage());
+            assertTrue(expected.getMessage().contains("name"),
+                    "Message should mention the missing 'name' parameter, was: " + expected.getMessage());
+        } finally {
+            assertTrue(req.release());
+        }
+    }
+
+    @Test
+    public void testFileUploadWithoutNameAttributeThrowsErrorDataDecoderException() {
+        String boundary = "861fbeab-cd20-470c-9609-d40a0f704466";
+        String content = "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; filename=\"upload.txt\"\r\n" +
+                "Content-Type: text/plain\r\n" +
+                "\r\n" +
+                "file-content\r\n" +
+                "--" + boundary + "--\r\n";
+
+        FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload",
+                Unpooled.copiedBuffer(content, CharsetUtil.US_ASCII));
+        req.headers().set(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
+        req.headers().set(HttpHeaderNames.CONTENT_LENGTH, content.length());
+
+        try {
+            HttpPostMultipartRequestDecoder decoder = this.builder().buildMultipart(req);
+            decoder.getBodyHttpDatas();
+            fail("Was expecting an ErrorDataDecoderException");
+        } catch (HttpPostRequestDecoder.ErrorDataDecoderException expected) {
+            assertNotNull(expected.getMessage());
+            assertTrue(expected.getMessage().contains("name"),
+                    "Message should mention the missing 'name' parameter, was: " + expected.getMessage());
+        } finally {
+            assertTrue(req.release());
+        }
+    }
 }

--- a/multipart-vintage/src/test/java/io/netty/contrib/multipart/vintage/HttpPostMultiPartRequestDecoderTest.java
+++ b/multipart-vintage/src/test/java/io/netty/contrib/multipart/vintage/HttpPostMultiPartRequestDecoderTest.java
@@ -612,9 +612,7 @@ public class HttpPostMultiPartRequestDecoderTest {
             decoder.getBodyHttpDatas();
             fail("Was expecting an ErrorDataDecoderException");
         } catch (HttpPostRequestDecoder.ErrorDataDecoderException expected) {
-            assertNotNull(expected.getMessage());
-            assertTrue(expected.getMessage().contains("name"),
-                    "Message should mention the missing 'name' parameter, was: " + expected.getMessage());
+            assertMissingNameExceptionMatchesQuirk(expected);
         } finally {
             assertTrue(req.release());
         }
@@ -640,11 +638,21 @@ public class HttpPostMultiPartRequestDecoderTest {
             decoder.getBodyHttpDatas();
             fail("Was expecting an ErrorDataDecoderException");
         } catch (HttpPostRequestDecoder.ErrorDataDecoderException expected) {
-            assertNotNull(expected.getMessage());
-            assertTrue(expected.getMessage().contains("name"),
-                    "Message should mention the missing 'name' parameter, was: " + expected.getMessage());
+            assertMissingNameExceptionMatchesQuirk(expected);
         } finally {
             assertTrue(req.release());
+        }
+    }
+
+    private void assertMissingNameExceptionMatchesQuirk(HttpPostRequestDecoder.ErrorDataDecoderException thrown) {
+        if (quirk) {
+            // Legacy behavior: NPE from dereferencing the missing name attribute is wrapped.
+            assertTrue(thrown.getCause() instanceof NullPointerException,
+                    "Expected legacy NPE cause when quirks are enabled, was: " + thrown.getCause());
+        } else {
+            // New behavior: descriptive message identifies the missing parameter, no wrapped cause.
+            assertEquals("Content-Disposition is missing required 'name' parameter", thrown.getMessage());
+            assertNull(thrown.getCause());
         }
     }
 }


### PR DESCRIPTION
## Problem

When a client sends a `multipart/form-data` request whose `Content-Disposition` header is missing the required `name=` parameter (e.g., the attack-style payloads referenced in netty/netty#16176), `HttpPostMultipartRequestDecoder` in the vintage module surfaces an opaque NPE:

```
java.lang.NullPointerException: Cannot invoke
  "io.netty.handler.codec.http.multipart.Attribute.getValue()"
  because "nameAttribute" is null
    at HttpPostMultipartRequestDecoder.decodeMultipart(...)
```

Operators get no hint about which part of the request was malformed, and the decoder relies on `catch (NullPointerException)` as its validation mechanism.

## Root Cause

`currentFieldAttributes.get(HttpHeaderValues.NAME)` returns `null` when the inbound `Content-Disposition` has no `name=` parameter. Both `getAttribute` (FIELD branch) and `getFileUpload` dereference the resulting `Attribute` via `nameAttribute.getValue()` without first checking for null. The surrounding `catch (NullPointerException | IllegalArgumentException | IOException)` around `factory.createAttribute(...)` produces the confusing message above.

## Fix

Add an explicit `nameAttribute == null` check in both `getAttribute()` and `getFileUpload()` before the `cleanString(nameAttribute.getValue())` dereference, throwing `ErrorDataDecoderException("Content-Disposition is missing required 'name' parameter")`.

Because the `multipart-vintage` module promises **100% behavioral compatibility** with the legacy Netty 4 decoder when all quirks are enabled (verified by `MultipartComparisonTest`), the new check is gated behind a new `DecoderQuirk`:

- **`NPE_ON_MISSING_CONTENT_DISPOSITION_NAME`** — when enabled, preserves the legacy NPE-wrapped-in-`ErrorDataDecoderException`. When disabled (the new default for builder users who do not call `.enableAllQuirks()`), the decoder throws the descriptive exception.

Users of the deprecated constructors and anyone calling `.enableAllQuirks()` (including the comparison fuzz suite) see unchanged behavior. New users who construct via `HttpPostRequestDecoder.builder()` get the improved error.

## Tests Added

| Change point | Test |
|---|---|
| Null check in `getAttribute` FIELD branch | `testFieldWithoutNameAttributeThrowsErrorDataDecoderException` — sends a multipart field with `Content-Disposition: form-data` (no `name=`) and asserts `ErrorDataDecoderException` whose message mentions the `name` parameter. Runs under both `quirk=false` (clean message) and `quirk=true` (NPE-wrapped message). |
| Null check in `getFileUpload` | `testFileUploadWithoutNameAttributeThrowsErrorDataDecoderException` — sends a file upload with `Content-Disposition: form-data; filename="upload.txt"` (no `name=`) and asserts the same. Runs under both quirk modes. |

Both tests pass in both parameterized runs. Full suite: `mvn test` → multipart-core 35/35, multipart-vintage 233/233 (2 pre-existing skips unrelated to this change), including the 58 fuzz-corpus cases in `MultipartComparisonTest` which assert 100% parity with the legacy decoder — the quirk gate keeps those green.

## Impact

- **Default behavior (no quirks)**: malformed multipart requests lacking `name=` are rejected with a clear `ErrorDataDecoderException` whose message identifies the missing parameter. The exception type is unchanged, so existing `catch` blocks behave the same.
- **Legacy/compat behavior (`.enableAllQuirks()` or deprecated constructors)**: unchanged — the NPE-wrapped-in-`ErrorDataDecoderException` is still produced, preserving the drop-in-replacement promise.
- No public API surface is removed; one enum value added to `DecoderQuirk` following the existing per-bug pattern (e.g., `CONSERVATIVE_LF_BACKTRACK`, `DISABLE_EARLY_MIXED_END`).
- Scope is limited to `HttpPostMultipartRequestDecoder` in the vintage module plus the one `DecoderQuirk` enum addition; `HttpPostStandardRequestDecoder`, `UrlEncodedDecoder`, and other paths are untouched.

## Background

Migrated from netty/netty#16688 per @yawkat's recommendation in that thread. Fixes netty/netty#16176.